### PR TITLE
feat: initialize urban rail power assessment frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>城市轨道交通供电设备状态评估系统</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "urban-rail-power-assessment",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@element-plus/icons-vue": "^2.3.1",
+    "echarts": "^5.5.0",
+    "element-plus": "^2.5.7",
+    "pinia": "^2.1.7",
+    "vue": "^3.4.21",
+    "vue-router": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@vitejs/plugin-vue": "^5.0.4",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0",
+    "vue-tsc": "^2.0.6"
+  }
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,0 +1,12 @@
+<template>
+  <router-view />
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+:host {
+  display: contents;
+}
+</style>

--- a/frontend/src/assets/styles/global.scss
+++ b/frontend/src/assets/styles/global.scss
@@ -1,0 +1,45 @@
+:root {
+  --primary-color: #165dff;
+  --secondary-color: #f5f7fa;
+  --text-color: #1f2d3d;
+  --muted-color: #6b778c;
+  --success-color: #52c41a;
+  --warning-color: #faad14;
+  --danger-color: #f56c6c;
+  font-size: 16px;
+}
+
+body {
+  margin: 0;
+  font-family: 'Microsoft YaHei', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background-color: #f2f4f8;
+  color: var(--text-color);
+}
+
+html,
+body,
+#app {
+  min-height: 100%;
+}
+
+.el-card {
+  border-radius: 12px;
+}
+
+.el-button.is-text {
+  color: var(--primary-color);
+}
+
+.el-menu {
+  border-right: none;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+}

--- a/frontend/src/charts/BarChart.vue
+++ b/frontend/src/charts/BarChart.vue
@@ -1,0 +1,81 @@
+<template>
+  <div ref="chartRef" class="chart" />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import * as echarts from 'echarts/core';
+import { BarChart as EBarChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([EBarChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+const props = defineProps<{
+  title: string;
+  categories: string[];
+  values: number[];
+}>();
+
+const chartRef = ref<HTMLDivElement>();
+let chart: echarts.ECharts | null = null;
+
+const render = () => {
+  if (!chartRef.value) return;
+  if (!chart) {
+    chart = echarts.init(chartRef.value);
+  }
+  chart.setOption({
+    title: { text: props.title, left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'axis' },
+    grid: { left: '3%', right: '3%', bottom: '3%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: props.categories,
+      axisLabel: { color: '#1f2d3d', interval: 0, rotate: 18 }
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: { color: '#1f2d3d' }
+    },
+    series: [
+      {
+        name: '贡献度',
+        type: 'bar',
+        data: props.values,
+        itemStyle: {
+          color: '#165dff',
+          borderRadius: [6, 6, 0, 0]
+        }
+      }
+    ]
+  });
+};
+
+const resize = () => chart?.resize();
+
+onMounted(() => {
+  render();
+  window.addEventListener('resize', resize);
+});
+
+watch(
+  () => ({ ...props }),
+  () => {
+    render();
+  }
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', resize);
+  chart?.dispose();
+  chart = null;
+});
+</script>
+
+<style scoped>
+.chart {
+  width: 100%;
+  height: 320px;
+}
+</style>

--- a/frontend/src/charts/RadarChart.vue
+++ b/frontend/src/charts/RadarChart.vue
@@ -1,0 +1,88 @@
+<template>
+  <div ref="chartRef" class="chart" />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import * as echarts from 'echarts/core';
+import { RadarChart as ERadarChart } from 'echarts/charts';
+import { TitleComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([ERadarChart, TitleComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+const props = defineProps<{
+  title: string;
+  indicator: { name: string; max: number }[];
+  value: number[];
+}>();
+
+const chartRef = ref<HTMLDivElement>();
+let chart: echarts.ECharts | null = null;
+
+const render = () => {
+  if (!chartRef.value) return;
+  if (!chart) {
+    chart = echarts.init(chartRef.value);
+  }
+  chart.setOption({
+    title: { text: props.title, left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: {},
+    radar: {
+      indicator: props.indicator,
+      radius: '60%',
+      splitNumber: 5,
+      axisName: {
+        color: '#1f2d3d'
+      }
+    },
+    series: [
+      {
+        name: '指标得分',
+        type: 'radar',
+        data: [
+          {
+            value: props.value,
+            areaStyle: {
+              color: 'rgba(22,93,255,0.35)'
+            },
+            lineStyle: {
+              color: '#165dff'
+            },
+            symbolSize: 6
+          }
+        ]
+      }
+    ]
+  });
+};
+
+const resize = () => {
+  chart?.resize();
+};
+
+onMounted(() => {
+  render();
+  window.addEventListener('resize', resize);
+});
+
+watch(
+  () => ({ ...props }),
+  () => {
+    render();
+  }
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', resize);
+  chart?.dispose();
+  chart = null;
+});
+</script>
+
+<style scoped>
+.chart {
+  width: 100%;
+  height: 320px;
+}
+</style>

--- a/frontend/src/charts/TrendChart.vue
+++ b/frontend/src/charts/TrendChart.vue
@@ -1,0 +1,84 @@
+<template>
+  <div ref="chartRef" class="chart" />
+</template>
+
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import * as echarts from 'echarts/core';
+import { LineChart as ELineChart } from 'echarts/charts';
+import { GridComponent, TooltipComponent, LegendComponent } from 'echarts/components';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([ELineChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+const props = defineProps<{
+  title: string;
+  categories: string[];
+  values: number[];
+}>();
+
+const chartRef = ref<HTMLDivElement>();
+let chart: echarts.ECharts | null = null;
+
+const render = () => {
+  if (!chartRef.value) return;
+  if (!chart) {
+    chart = echarts.init(chartRef.value);
+  }
+  chart.setOption({
+    title: { text: props.title, left: 'center', textStyle: { fontSize: 14 } },
+    tooltip: { trigger: 'axis' },
+    grid: { left: '3%', right: '3%', bottom: '3%', containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: props.categories,
+      boundaryGap: false,
+      axisLabel: { color: '#1f2d3d' }
+    },
+    yAxis: {
+      type: 'value',
+      axisLabel: { color: '#1f2d3d' },
+      min: 0,
+      max: 100
+    },
+    series: [
+      {
+        name: '综合得分',
+        type: 'line',
+        data: props.values,
+        smooth: true,
+        areaStyle: { color: 'rgba(22,93,255,0.15)' },
+        lineStyle: { color: '#165dff', width: 2 },
+        symbolSize: 8
+      }
+    ]
+  });
+};
+
+const resize = () => chart?.resize();
+
+onMounted(() => {
+  render();
+  window.addEventListener('resize', resize);
+});
+
+watch(
+  () => ({ ...props }),
+  () => {
+    render();
+  }
+);
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', resize);
+  chart?.dispose();
+  chart = null;
+});
+</script>
+
+<style scoped>
+.chart {
+  width: 100%;
+  height: 280px;
+}
+</style>

--- a/frontend/src/config/powerEvaluationConfig.ts
+++ b/frontend/src/config/powerEvaluationConfig.ts
@@ -1,0 +1,415 @@
+import type { DeviceRecord, DeviceSystem } from '@/types/device';
+import type { DeviceEvaluationResult, IndicatorSystemConfig, WeightScheme } from '@/types/evaluation';
+
+export const deviceSystems: DeviceSystem[] = [
+  {
+    id: 'main-substation',
+    name: '主变电所',
+    description: '供电系统核心枢纽，负责牵引电能的集中变换与分配。',
+    categories: [
+      '开关设备',
+      '母线',
+      '变压器',
+      '电抗器',
+      '互感器',
+      '电容器',
+      '隔离开关',
+      '交直流电源',
+      '各类电缆及光缆',
+      '保护装置',
+      '变电所综合自动化',
+      '避雷装置',
+      '无功补偿系统'
+    ]
+  },
+  {
+    id: 'sub-substation',
+    name: '子变电所',
+    description: '配合主变电所完成牵引供电与降压供电任务。',
+    categories: [
+      '开关设备',
+      '变压器',
+      'OVPD',
+      '负极柜',
+      '整流器柜',
+      '交直流电源',
+      '各类电缆及光缆',
+      '回流装置',
+      '变电所综合自动化',
+      '保护装置及二次回路'
+    ]
+  },
+  {
+    id: 'catenary',
+    name: '接触网系统',
+    description: '刚柔性接触网承载牵引电流，是列车受流的关键系统。',
+    categories: ['汇流排', '接触线', '承力索', '架空地线', '支柱', '软横跨', '上网隔离开关']
+  },
+  {
+    id: 'power-lighting',
+    name: '动力照明系统',
+    description: '动力与照明用电系统，预留扩展接口。',
+    categories: ['占位待建']
+  },
+  {
+    id: 'stray-current',
+    name: '杂散电流防护系统',
+    description: '用于控制与引导杂散电流的防护设施。',
+    categories: ['占位待建']
+  },
+  {
+    id: 'power-monitor',
+    name: '电力监控系统',
+    description: '对供电设备与参数进行实时监测与管理。',
+    categories: ['占位待建']
+  }
+];
+
+export const seedDevices: DeviceRecord[] = [
+  {
+    id: 'MSS-SW-001',
+    name: '主变电所开关柜A1',
+    code: 'MSS-SW-001',
+    systemId: 'main-substation',
+    category: '开关设备',
+    location: '主变电所A区-开关间',
+    commissionDate: '2017-06-18',
+    status: '正常',
+    ownerRole: 'admin',
+    keyParams: {
+      额定电流: '1250A',
+      额定电压: '27.5kV',
+      操作机构: '智能真空',
+      制造商: '国电南瑞'
+    },
+    metrics: [
+      {
+        indicatorId: 'life-cycle.overdue-service',
+        name: '超出规定服役年限',
+        value: 2.5,
+        unit: '年',
+        updatedAt: '2024-12-01'
+      },
+      {
+        indicatorId: 'reliability.failure-rate',
+        name: '故障率',
+        value: 0.8,
+        unit: '次/万小时',
+        updatedAt: '2024-12-01'
+      },
+      {
+        indicatorId: 'safety.operation-impact',
+        name: '对行车安全影响',
+        value: '无影响',
+        updatedAt: '2024-12-01'
+      },
+      {
+        indicatorId: 'support.spare-part',
+        name: '备品备件供应',
+        value: '满足',
+        updatedAt: '2024-12-01'
+      }
+    ]
+  },
+  {
+    id: 'MSS-TR-003',
+    name: '主变电所主变压器T3',
+    code: 'MSS-TR-003',
+    systemId: 'main-substation',
+    category: '变压器',
+    location: '主变电所B区-变压器室',
+    commissionDate: '2012-09-05',
+    status: '关注',
+    ownerRole: 'admin',
+    keyParams: {
+      容量: '2x40MVA',
+      冷却方式: 'ONAF',
+      分接范围: '±8x1.5%'
+    },
+    metrics: [
+      {
+        indicatorId: 'life-cycle.overdue-service',
+        name: '超出规定服役年限',
+        value: 7,
+        unit: '年',
+        updatedAt: '2024-11-20'
+      },
+      {
+        indicatorId: 'reliability.failure-rate',
+        name: '故障率',
+        value: 1.4,
+        unit: '次/万小时',
+        updatedAt: '2024-11-20'
+      },
+      {
+        indicatorId: 'reliability.mtbf',
+        name: '无故障间隔时间',
+        value: 2800,
+        unit: '小时',
+        updatedAt: '2024-11-20'
+      },
+      {
+        indicatorId: 'function.integrity',
+        name: '设备功能完备性',
+        value: '一般符合',
+        updatedAt: '2024-11-20'
+      }
+    ]
+  },
+  {
+    id: 'SUB-REC-010',
+    name: '整流器柜10号',
+    code: 'SUB-REC-010',
+    systemId: 'sub-substation',
+    category: '整流器柜',
+    location: 'XX线南区子变电所',
+    commissionDate: '2019-03-12',
+    status: '正常',
+    ownerRole: 'user',
+    keyParams: {
+      类型: '12脉波整流',
+      冷却: '强迫风冷',
+      容量: '6MW'
+    },
+    metrics: [
+      {
+        indicatorId: 'life-cycle.overdue-service',
+        name: '超出规定服役年限',
+        value: 1,
+        unit: '年',
+        updatedAt: '2024-12-05'
+      },
+      {
+        indicatorId: 'reliability.failure-rate',
+        name: '故障率',
+        value: 0.6,
+        unit: '次/万小时',
+        updatedAt: '2024-12-05'
+      },
+      {
+        indicatorId: 'support.spare-part',
+        name: '备品备件供应',
+        value: '基本满足',
+        updatedAt: '2024-12-05'
+      }
+    ]
+  },
+  {
+    id: 'CAT-CON-021',
+    name: '接触线段落K21',
+    code: 'CAT-CON-021',
+    systemId: 'catenary',
+    category: '接触线',
+    location: '区间K21+300至K21+800',
+    commissionDate: '2015-11-01',
+    status: '预警',
+    ownerRole: 'admin',
+    keyParams: {
+      型号: 'CUAg 120',
+      张力: '21kN',
+      接触面磨耗: '30%'
+    },
+    metrics: [
+      {
+        indicatorId: 'life-cycle.overdue-service',
+        name: '超出规定服役年限',
+        value: 4.5,
+        unit: '年',
+        updatedAt: '2024-10-11'
+      },
+      {
+        indicatorId: 'safety.operation-impact',
+        name: '对行车安全影响',
+        value: '一般',
+        updatedAt: '2024-10-11'
+      },
+      {
+        indicatorId: 'function.integrity',
+        name: '设备功能完备性',
+        value: '符合',
+        updatedAt: '2024-10-11'
+      }
+    ]
+  }
+];
+
+export const indicatorSystems: IndicatorSystemConfig[] = [
+  {
+    id: 'standard-2024',
+    name: '供电设备状态评估标准方案（2024版）',
+    applicableSystems: ['main-substation', 'sub-substation', 'catenary', 'power-monitor'],
+    minPrimarySelection: 3,
+    tree: [
+      {
+        id: 'life-cycle',
+        name: '寿命状态',
+        definition: '设备服役年限与折旧状况',
+        direction: 'negative',
+        unit: '年',
+        thresholdDescription: '越大代表服役年限越长，需要关注老化情况',
+        rules: [
+          { label: '[0,3)年', range: [0, 3], score: 100 },
+          { label: '[3,5)年', range: [3, 5], score: 80 },
+          { label: '≥5年', range: [5, null], score: 60 }
+        ],
+        children: [
+          {
+            id: 'life-cycle.overdue-service',
+            name: '超出规定服役年限',
+            definition: '设备服役年限超出设计年限的时间差',
+            unit: '年',
+            direction: 'negative',
+            rules: [
+              { label: '[0,3)', range: [0, 3], score: 100 },
+              { label: '[3,5)', range: [3, 5], score: 80 },
+              { label: '≥5', range: [5, null], score: 60 }
+            ]
+          }
+        ]
+      },
+      {
+        id: 'safety',
+        name: '安全影响',
+        definition: '设备状态对行车及供电安全的影响程度',
+        direction: 'negative',
+        rules: [
+          { label: '无影响', value: '无影响', score: 100 },
+          { label: '一般', value: '一般', score: 80 },
+          { label: '较大', value: '较大', score: 60 },
+          { label: '严重', value: '严重', score: 40 }
+        ],
+        children: [
+          {
+            id: 'safety.operation-impact',
+            name: '对行车安全性的影响',
+            definition: '评估设备异常对列车行车安全的影响等级',
+            direction: 'negative',
+            rules: [
+              { label: '无影响', value: '无影响', score: 100 },
+              { label: '一般', value: '一般', score: 80 },
+              { label: '较大', value: '较大', score: 60 },
+              { label: '严重', value: '严重', score: 40 }
+            ]
+          }
+        ]
+      },
+      {
+        id: 'reliability',
+        name: '可靠性',
+        definition: '设备运行故障频率及稳定性指标',
+        direction: 'negative',
+        rules: [
+          { label: '故障率≤0.5', range: [null, 0.5], score: 100 },
+          { label: '0.5~1.0', range: [0.5, 1], score: 85 },
+          { label: '1.0~1.5', range: [1, 1.5], score: 70 },
+          { label: '>1.5', range: [1.5, null], score: 55 }
+        ],
+        children: [
+          {
+            id: 'reliability.failure-rate',
+            name: '故障率',
+            definition: '设备单位时间内发生故障的次数',
+            unit: '次/万小时',
+            direction: 'negative',
+            rules: [
+              { label: '≤0.5', range: [null, 0.5], score: 100 },
+              { label: '0.5~1.0', range: [0.5, 1], score: 85 },
+              { label: '1.0~1.5', range: [1, 1.5], score: 70 },
+              { label: '>1.5', range: [1.5, null], score: 55 }
+            ]
+          },
+          {
+            id: 'reliability.mtbf',
+            name: '无故障间隔时间',
+            definition: '设备平均无故障运行时间',
+            unit: '小时',
+            direction: 'positive',
+            rules: [
+              { label: '≥4000', range: [4000, null], score: 100 },
+              { label: '3000~4000', range: [3000, 4000], score: 85 },
+              { label: '2000~3000', range: [2000, 3000], score: 70 },
+              { label: '<2000', range: [null, 2000], score: 55 }
+            ]
+          }
+        ]
+      },
+      {
+        id: 'function',
+        name: '功能完备性',
+        definition: '设备各单元功能满足设计要求的程度',
+        direction: 'positive',
+        rules: [
+          { label: '符合', value: '符合', score: 100 },
+          { label: '一般符合', value: '一般符合', score: 80 },
+          { label: '不符合', value: '不符合', score: 60 }
+        ],
+        children: [
+          {
+            id: 'function.integrity',
+            name: '设备功能完备性',
+            definition: '通过现场检查对功能状态进行等级划分',
+            direction: 'positive',
+            rules: [
+              { label: '符合', value: '符合', score: 100 },
+              { label: '一般符合', value: '一般符合', score: 80 },
+              { label: '不符合', value: '不符合', score: 60 }
+            ]
+          }
+        ]
+      },
+      {
+        id: 'support',
+        name: '保障能力',
+        definition: '备品备件、检修资源满足程度',
+        direction: 'positive',
+        rules: [
+          { label: '满足', value: '满足', score: 100 },
+          { label: '基本满足', value: '基本满足', score: 80 },
+          { label: '无备件', value: '无备件', score: 60 }
+        ],
+        children: [
+          {
+            id: 'support.spare-part',
+            name: '备品备件供应',
+            definition: '备件储备与供应满足检修需求的程度',
+            direction: 'positive',
+            rules: [
+              { label: '满足', value: '满足', score: 100 },
+              { label: '基本满足', value: '基本满足', score: 80 },
+              { label: '无备件', value: '无备件', score: 60 }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export const defaultWeightSchemes: WeightScheme[] = [
+  {
+    id: 'scheme-ahp-default',
+    name: 'AHP标准权重',
+    createdAt: '2024-12-01T08:00:00+08:00',
+    method: 'AHP',
+    description: '依据专家经验建立的基准权重向量',
+    indicatorWeights: {
+      'life-cycle.overdue-service': 0.25,
+      'safety.operation-impact': 0.2,
+      'reliability.failure-rate': 0.18,
+      'reliability.mtbf': 0.15,
+      'function.integrity': 0.12,
+      'support.spare-part': 0.1
+    }
+  }
+];
+
+export const evaluationLevelRules = [
+  { level: 'A', min: 90, max: 100, description: '正常、可靠性稳定' },
+  { level: 'B', min: 80, max: 90, description: '轻微问题，需部分维护' },
+  { level: 'C', min: 70, max: 80, description: '早期故障特征，需及时维修' },
+  { level: 'D', min: 0, max: 70, description: '问题较重，需大修或更换' }
+] as const;
+
+export const evaluationHistoryKey = 'urban-rail-evaluation-history';
+
+export type EvaluationHistory = DeviceEvaluationResult[];

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue';
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>;
+  export default component;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,0 +1,18 @@
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import ElementPlus from 'element-plus';
+import zhCn from 'element-plus/es/locale/lang/zh-cn';
+import 'element-plus/dist/index.css';
+import '@/assets/styles/global.scss';
+
+import App from './App.vue';
+import router from './router';
+
+const app = createApp(App);
+
+const pinia = createPinia();
+app.use(pinia);
+app.use(router);
+app.use(ElementPlus, { locale: zhCn });
+
+app.mount('#app');

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,0 +1,67 @@
+import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router';
+import { useAuthStore } from '@/stores/auth';
+
+const routes: RouteRecordRaw[] = [
+  { path: '/', redirect: '/login' },
+  {
+    path: '/login',
+    name: 'login',
+    component: () => import('@/views/Login.vue'),
+    meta: { public: true }
+  },
+  {
+    path: '/app',
+    name: 'app',
+    component: () => import('@/views/AppLayout.vue'),
+    children: [
+      { path: '', redirect: '/app/device' },
+      {
+        path: 'device',
+        name: 'device',
+        component: () => import('@/views/device/DevicePage.vue')
+      },
+      {
+        path: 'eval',
+        name: 'evaluation',
+        component: () => import('@/views/eval/EvaluationPage.vue')
+      },
+      {
+        path: 'settings',
+        name: 'settings',
+        component: () => import('@/views/SystemSettings.vue'),
+        meta: { requiresAdmin: true }
+      }
+    ]
+  }
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+});
+
+router.beforeEach((to, _from, next) => {
+  const auth = useAuthStore();
+  if (to.meta.public) {
+    if (to.name === 'login' && auth.isAuthenticated) {
+      next('/app');
+    } else {
+      next();
+    }
+    return;
+  }
+
+  if (!auth.isAuthenticated) {
+    next({ path: '/login', query: { redirect: to.fullPath } });
+    return;
+  }
+
+  if (to.meta.requiresAdmin && auth.role !== 'admin') {
+    next('/app');
+    return;
+  }
+
+  next();
+});
+
+export default router;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia';
+import { computed, reactive, watch } from 'vue';
+
+type Role = 'user' | 'admin';
+
+const STORAGE_KEY = 'urban-rail-auth';
+
+interface PersistedAuthState {
+  username: string | null;
+  role: Role;
+  isAuthenticated: boolean;
+}
+
+const getInitialState = (): PersistedAuthState => {
+  if (typeof window === 'undefined') {
+    return { username: null, role: 'user', isAuthenticated: false };
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return { username: null, role: 'user', isAuthenticated: false };
+    }
+    const parsed = JSON.parse(stored) as PersistedAuthState;
+    return {
+      username: parsed.username ?? null,
+      role: parsed.role ?? 'user',
+      isAuthenticated: parsed.isAuthenticated ?? false
+    };
+  } catch (error) {
+    console.warn('读取登录状态失败', error);
+    return { username: null, role: 'user', isAuthenticated: false };
+  }
+};
+
+export const useAuthStore = defineStore('auth', () => {
+  const state = reactive<PersistedAuthState>(getInitialState());
+
+  const role = computed(() => state.role);
+  const username = computed(() => state.username ?? '访客');
+  const isAuthenticated = computed(() => state.isAuthenticated);
+
+  const login = (payload: { username: string; role: Role }) => {
+    state.username = payload.username;
+    state.role = payload.role;
+    state.isAuthenticated = true;
+  };
+
+  const logout = () => {
+    state.username = null;
+    state.role = 'user';
+    state.isAuthenticated = false;
+  };
+
+  if (typeof window !== 'undefined') {
+    watch(
+      () => ({ ...state }),
+      (val) => {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
+      },
+      { deep: true }
+    );
+  }
+
+  return {
+    role,
+    username,
+    isAuthenticated,
+    login,
+    logout,
+    state
+  };
+});

--- a/frontend/src/stores/device.ts
+++ b/frontend/src/stores/device.ts
@@ -1,0 +1,139 @@
+import { defineStore } from 'pinia';
+import { computed, reactive, ref, watch } from 'vue';
+import { deviceSystems, seedDevices } from '@/config/powerEvaluationConfig';
+import type { DeviceFilter, DeviceRecord, DeviceStatus, DeviceSystem } from '@/types/device';
+
+const STORAGE_KEY = 'urban-rail-devices';
+
+const getPersistedDevices = (): DeviceRecord[] => {
+  if (typeof window === 'undefined') {
+    return [...seedDevices];
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [...seedDevices];
+    }
+    const parsed = JSON.parse(stored) as DeviceRecord[];
+    return parsed.length ? parsed : [...seedDevices];
+  } catch (error) {
+    console.error('加载设备数据失败', error);
+    return [...seedDevices];
+  }
+};
+
+export const useDeviceStore = defineStore('device', () => {
+  const systems = ref<DeviceSystem[]>(deviceSystems);
+  const devices = ref<DeviceRecord[]>(getPersistedDevices());
+
+  const filter = reactive<DeviceFilter>({
+    keyword: '',
+    status: '全部',
+    category: '全部'
+  });
+
+  const currentSystemId = ref<string>(systems.value[0]?.id ?? '');
+
+  const filteredDevices = computed(() => {
+    return devices.value.filter((item) => {
+      if (item.systemId !== currentSystemId.value) {
+        return false;
+      }
+      if (filter.status !== '全部' && item.status !== filter.status) {
+        return false;
+      }
+      if (filter.category !== '全部' && item.category !== filter.category) {
+        return false;
+      }
+      if (filter.keyword) {
+        const keyword = filter.keyword.trim().toLowerCase();
+        return (
+          item.name.toLowerCase().includes(keyword) ||
+          item.code.toLowerCase().includes(keyword) ||
+          item.location.toLowerCase().includes(keyword)
+        );
+      }
+      return true;
+    });
+  });
+
+  const setSystem = (id: string) => {
+    currentSystemId.value = id;
+    const currentSystem = systems.value.find((sys) => sys.id === id);
+    if (currentSystem) {
+      filter.category = '全部';
+    }
+  };
+
+  const addDevice = (record: DeviceRecord) => {
+    devices.value.push(record);
+  };
+
+  const updateDevice = (id: string, payload: Partial<DeviceRecord>) => {
+    const index = devices.value.findIndex((item) => item.id === id);
+    if (index !== -1) {
+      devices.value[index] = { ...devices.value[index], ...payload };
+    }
+  };
+
+  const upsertDevice = (record: DeviceRecord) => {
+    const index = devices.value.findIndex((item) => item.id === record.id);
+    if (index === -1) {
+      addDevice(record);
+    } else {
+      devices.value[index] = { ...devices.value[index], ...record };
+    }
+  };
+
+  const removeDevice = (id: string) => {
+    devices.value = devices.value.filter((item) => item.id !== id);
+  };
+
+  const setDeviceStatus = (id: string, status: DeviceStatus) => {
+    const device = devices.value.find((item) => item.id === id);
+    if (device) {
+      device.status = status;
+    }
+  };
+
+  const recordEvaluation = (payload: { id: string; score: number; level: string; evaluatedAt: string }) => {
+    const device = devices.value.find((item) => item.id === payload.id);
+    if (device) {
+      device.score = payload.score;
+      device.status =
+        payload.level === 'A'
+          ? '正常'
+          : payload.level === 'B'
+          ? '关注'
+          : payload.level === 'C'
+          ? '预警'
+          : '严重';
+      device.lastEvalAt = payload.evaluatedAt;
+    }
+  };
+
+  if (typeof window !== 'undefined') {
+    watch(
+      devices,
+      (val) => {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(val));
+      },
+      { deep: true }
+    );
+  }
+
+  return {
+    systems,
+    devices,
+    filter,
+    currentSystemId,
+    filteredDevices,
+    setSystem,
+    addDevice,
+    upsertDevice,
+    updateDevice,
+    removeDevice,
+    setDeviceStatus,
+    recordEvaluation
+  };
+});

--- a/frontend/src/stores/evaluation.ts
+++ b/frontend/src/stores/evaluation.ts
@@ -1,0 +1,238 @@
+import { defineStore } from 'pinia';
+import { computed, ref, watch } from 'vue';
+import {
+  defaultWeightSchemes,
+  evaluationHistoryKey,
+  indicatorSystems
+} from '@/config/powerEvaluationConfig';
+import type {
+  DeviceEvaluationResult,
+  IndicatorNode,
+  IndicatorSystemConfig,
+  WeightScheme
+} from '@/types/evaluation';
+
+const WEIGHT_STORAGE_KEY = 'urban-rail-weight-schemes';
+const SELECTION_STORAGE_KEY = 'urban-rail-selected-indicators';
+
+const flattenIndicators = (nodes: IndicatorNode[]): Record<string, IndicatorNode> => {
+  const result: Record<string, IndicatorNode> = {};
+  const walk = (items: IndicatorNode[]) => {
+    items.forEach((item) => {
+      result[item.id] = item;
+      if (item.children?.length) {
+        walk(item.children);
+      }
+    });
+  };
+  walk(nodes);
+  return result;
+};
+
+const loadWeightSchemes = (): WeightScheme[] => {
+  if (typeof window === 'undefined') {
+    return [...defaultWeightSchemes];
+  }
+  try {
+    const stored = window.localStorage.getItem(WEIGHT_STORAGE_KEY);
+    if (!stored) {
+      return [...defaultWeightSchemes];
+    }
+    const parsed = JSON.parse(stored) as WeightScheme[];
+    return parsed.length ? parsed : [...defaultWeightSchemes];
+  } catch (error) {
+    console.warn('加载权重方案失败', error);
+    return [...defaultWeightSchemes];
+  }
+};
+
+const loadSelections = (): string[] => {
+  if (typeof window === 'undefined') {
+    return Object.keys(defaultWeightSchemes[0].indicatorWeights);
+  }
+  try {
+    const stored = window.localStorage.getItem(SELECTION_STORAGE_KEY);
+    if (!stored) {
+      return Object.keys(defaultWeightSchemes[0].indicatorWeights);
+    }
+    const parsed = JSON.parse(stored) as string[];
+    return parsed.length ? parsed : Object.keys(defaultWeightSchemes[0].indicatorWeights);
+  } catch (error) {
+    console.warn('加载指标选择失败', error);
+    return Object.keys(defaultWeightSchemes[0].indicatorWeights);
+  }
+};
+
+const loadHistory = (): DeviceEvaluationResult[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+  try {
+    const stored = window.localStorage.getItem(evaluationHistoryKey);
+    if (!stored) {
+      return [];
+    }
+    return JSON.parse(stored) as DeviceEvaluationResult[];
+  } catch (error) {
+    console.warn('加载历史评估失败', error);
+    return [];
+  }
+};
+
+export const useEvaluationStore = defineStore('evaluation', () => {
+  const systemOptions = ref<IndicatorSystemConfig[]>(indicatorSystems);
+  const activeSystemId = ref<string>(systemOptions.value[0]?.id ?? '');
+
+  const indicatorMap = computed(() => {
+    const system = systemOptions.value.find((item) => item.id === activeSystemId.value);
+    return system ? flattenIndicators(system.tree) : {};
+  });
+
+  const selectedIndicatorIds = ref<string[]>(loadSelections());
+  const weightSchemes = ref<WeightScheme[]>(loadWeightSchemes());
+  const activeSchemeId = ref<string>(weightSchemes.value[0]?.id ?? '');
+  const history = ref<DeviceEvaluationResult[]>(loadHistory());
+
+  const activeSystem = computed(() =>
+    systemOptions.value.find((item) => item.id === activeSystemId.value) ?? null
+  );
+
+  const selectedIndicators = computed(() =>
+    selectedIndicatorIds.value
+      .map((id) => indicatorMap.value[id])
+      .filter((item): item is IndicatorNode => Boolean(item))
+  );
+
+  const activeScheme = computed(() =>
+    weightSchemes.value.find((item) => item.id === activeSchemeId.value) ?? null
+  );
+
+  const validateSelection = () => {
+    const primaryIds = new Set(
+      selectedIndicators.value.map((indicator) => indicator.id.split('.')[0])
+    );
+    const min = activeSystem.value?.minPrimarySelection ?? 1;
+    return primaryIds.size >= min;
+  };
+
+  const setActiveSystem = (id: string) => {
+    activeSystemId.value = id;
+    const available = systemOptions.value
+      .find((item) => item.id === id)
+      ?.tree.flatMap((node) => node.children?.map((child) => child.id) ?? []) ?? [];
+    if (available.length) {
+      selectedIndicatorIds.value = selectedIndicatorIds.value.filter((id) =>
+        available.includes(id)
+      );
+      if (!selectedIndicatorIds.value.length) {
+        selectedIndicatorIds.value = available.slice(0, Math.min(3, available.length));
+      }
+    }
+  };
+
+  const toggleIndicator = (id: string, checked: boolean) => {
+    if (checked) {
+      if (!selectedIndicatorIds.value.includes(id)) {
+        selectedIndicatorIds.value.push(id);
+      }
+    } else {
+      selectedIndicatorIds.value = selectedIndicatorIds.value.filter((item) => item !== id);
+    }
+  };
+
+  const setIndicators = (ids: string[]) => {
+    selectedIndicatorIds.value = [...new Set(ids)];
+  };
+
+  const saveWeightScheme = (scheme: WeightScheme) => {
+    const index = weightSchemes.value.findIndex((item) => item.id === scheme.id);
+    if (index === -1) {
+      weightSchemes.value.push(scheme);
+    } else {
+      weightSchemes.value[index] = scheme;
+    }
+    activeSchemeId.value = scheme.id;
+  };
+
+  const deleteWeightScheme = (id: string) => {
+    weightSchemes.value = weightSchemes.value.filter((item) => item.id !== id);
+    if (activeSchemeId.value === id) {
+      activeSchemeId.value = weightSchemes.value[0]?.id ?? '';
+    }
+  };
+
+  const setActiveScheme = (id: string) => {
+    activeSchemeId.value = id;
+  };
+
+  const appendEvaluationHistory = (records: DeviceEvaluationResult[]) => {
+    history.value = [...records, ...history.value].slice(0, 30);
+  };
+
+  const clearHistory = () => {
+    history.value = [];
+  };
+
+  const exportSchemes = () => {
+    return JSON.stringify(weightSchemes.value, null, 2);
+  };
+
+  const importSchemes = (payload: string) => {
+    const parsed = JSON.parse(payload) as WeightScheme[];
+    if (!Array.isArray(parsed)) {
+      throw new Error('导入格式错误');
+    }
+    weightSchemes.value = parsed;
+    activeSchemeId.value = parsed[0]?.id ?? '';
+  };
+
+  if (typeof window !== 'undefined') {
+    watch(
+      weightSchemes,
+      (val) => {
+        window.localStorage.setItem(WEIGHT_STORAGE_KEY, JSON.stringify(val));
+      },
+      { deep: true }
+    );
+
+    watch(
+      selectedIndicatorIds,
+      (val) => {
+        window.localStorage.setItem(SELECTION_STORAGE_KEY, JSON.stringify(val));
+      },
+      { deep: true }
+    );
+
+    watch(
+      history,
+      (val) => {
+        window.localStorage.setItem(evaluationHistoryKey, JSON.stringify(val));
+      },
+      { deep: true }
+    );
+  }
+
+  return {
+    systemOptions,
+    activeSystemId,
+    activeSystem,
+    indicatorMap,
+    selectedIndicatorIds,
+    selectedIndicators,
+    weightSchemes,
+    activeSchemeId,
+    activeScheme,
+    history,
+    validateSelection,
+    setActiveSystem,
+    toggleIndicator,
+    setIndicators,
+    saveWeightScheme,
+    deleteWeightScheme,
+    setActiveScheme,
+    appendEvaluationHistory,
+    clearHistory,
+    exportSchemes,
+    importSchemes
+  };
+});

--- a/frontend/src/types/device.ts
+++ b/frontend/src/types/device.ts
@@ -1,0 +1,38 @@
+export type DeviceStatus = '正常' | '关注' | '预警' | '严重';
+
+export interface DeviceMetric {
+  indicatorId: string;
+  name: string;
+  value: number | string;
+  unit?: string;
+  updatedAt: string;
+}
+
+export interface DeviceRecord {
+  id: string;
+  name: string;
+  code: string;
+  systemId: string;
+  category: string;
+  location: string;
+  commissionDate: string;
+  status: DeviceStatus;
+  keyParams: Record<string, string | number>;
+  ownerRole: 'user' | 'admin';
+  metrics: DeviceMetric[];
+  lastEvalAt?: string;
+  score?: number;
+}
+
+export interface DeviceSystem {
+  id: string;
+  name: string;
+  description?: string;
+  categories: string[];
+}
+
+export interface DeviceFilter {
+  keyword: string;
+  status: DeviceStatus | '全部';
+  category: string | '全部';
+}

--- a/frontend/src/types/evaluation.ts
+++ b/frontend/src/types/evaluation.ts
@@ -1,0 +1,60 @@
+export type IndicatorDirection = 'positive' | 'negative' | 'interval';
+
+export interface IndicatorRule {
+  label: string;
+  description?: string;
+  range?: [number | null, number | null];
+  comparator?: '<' | '<=' | '>' | '>=' | '==' | '!=';
+  value?: number | string;
+  score: number;
+}
+
+export interface IndicatorNode {
+  id: string;
+  name: string;
+  definition: string;
+  unit?: string;
+  direction: IndicatorDirection;
+  thresholdDescription?: string;
+  rules: IndicatorRule[];
+  children?: IndicatorNode[];
+}
+
+export interface IndicatorSystemConfig {
+  id: string;
+  name: string;
+  applicableSystems: string[];
+  minPrimarySelection: number;
+  tree: IndicatorNode[];
+}
+
+export interface WeightScheme {
+  id: string;
+  name: string;
+  createdAt: string;
+  method: 'AHP' | 'Entropy' | 'Manual';
+  indicatorWeights: Record<string, number>;
+  description?: string;
+}
+
+export interface EvaluationResultDetail {
+  indicatorId: string;
+  indicatorName: string;
+  value: number;
+  rawValue: number | string;
+  normalized: number;
+  weight: number;
+  contribution: number;
+  score: number;
+  ruleMatched?: string;
+}
+
+export interface DeviceEvaluationResult {
+  deviceId: string;
+  deviceName: string;
+  systemId: string;
+  totalScore: number;
+  level: 'A' | 'B' | 'C' | 'D';
+  evaluatedAt: string;
+  details: EvaluationResultDetail[];
+}

--- a/frontend/src/utils/evaluation.ts
+++ b/frontend/src/utils/evaluation.ts
@@ -1,0 +1,199 @@
+import { evaluationLevelRules } from '@/config/powerEvaluationConfig';
+import type { DeviceRecord } from '@/types/device';
+import type {
+  EvaluationResultDetail,
+  IndicatorNode,
+  IndicatorRule,
+  WeightScheme
+} from '@/types/evaluation';
+
+export interface IndicatorScoreResult {
+  score: number;
+  matchedRule?: IndicatorRule;
+}
+
+export const matchIndicatorScore = (
+  indicator: IndicatorNode,
+  rawValue: number | string
+): IndicatorScoreResult => {
+  const rules = indicator.rules ?? [];
+  if (typeof rawValue === 'number') {
+    for (const rule of rules) {
+      if (!rule.range) continue;
+      const [min, max] = rule.range;
+      const lowerOk = min === null || rawValue >= min;
+      const upperOk = max === null || rawValue < max;
+      if (lowerOk && upperOk) {
+        return { score: rule.score, matchedRule: rule };
+      }
+    }
+  } else {
+    for (const rule of rules) {
+      if (rule.value === rawValue) {
+        return { score: rule.score, matchedRule: rule };
+      }
+    }
+  }
+  return { score: 60 };
+};
+
+export const normalizeValue = (
+  indicator: IndicatorNode,
+  rawValue: number,
+  dataset: number[]
+) => {
+  if (!dataset.length) return 0;
+  const min = Math.min(...dataset);
+  const max = Math.max(...dataset);
+  if (indicator.direction === 'positive') {
+    return max === min ? 1 : (rawValue - min) / (max - min);
+  }
+  if (indicator.direction === 'negative') {
+    return max === min ? 1 : (max - rawValue) / (max - min);
+  }
+  const mid = (max + min) / 2;
+  const range = max - min || 1;
+  return 1 - Math.abs(rawValue - mid) / (range / 2);
+};
+
+export const computeDeviceScore = (
+  device: DeviceRecord,
+  indicators: IndicatorNode[],
+  weights: Record<string, number>,
+  datasets?: Record<string, number[]>
+): { total: number; details: EvaluationResultDetail[] } => {
+  const details: EvaluationResultDetail[] = [];
+  let total = 0;
+  indicators.forEach((indicator) => {
+    const metric = device.metrics.find((item) => item.indicatorId === indicator.id);
+    if (!metric) {
+      return;
+    }
+    const rawValue = metric.value;
+    const dataset = datasets?.[indicator.id] ?? [];
+
+    const normalized =
+      typeof rawValue === 'number'
+        ? normalizeValue(indicator, rawValue, dataset.length ? dataset : [rawValue])
+        : 1;
+    const { score, matchedRule } = matchIndicatorScore(indicator, rawValue);
+    const weight = weights[indicator.id] ?? 0;
+    const contribution = score * weight;
+    total += contribution;
+    details.push({
+      indicatorId: indicator.id,
+      indicatorName: indicator.name,
+      value: typeof rawValue === 'number' ? Number(rawValue) : NaN,
+      rawValue,
+      normalized: Number.isFinite(normalized) ? normalized : 0,
+      weight,
+      contribution,
+      score,
+      ruleMatched: matchedRule?.label
+    });
+  });
+  return { total, details };
+};
+
+export const determineLevel = (score: number) => {
+  for (const rule of evaluationLevelRules) {
+    if (score >= rule.min && score < rule.max) {
+      return rule.level as 'A' | 'B' | 'C' | 'D';
+    }
+  }
+  return 'D';
+};
+
+export const ahpPowerIteration = (matrix: number[][], maxIterations = 100, tolerance = 1e-6) => {
+  const n = matrix.length;
+  let vector = Array(n).fill(1 / n);
+  for (let iter = 0; iter < maxIterations; iter += 1) {
+    const next = Array(n).fill(0);
+    for (let i = 0; i < n; i += 1) {
+      for (let j = 0; j < n; j += 1) {
+        next[i] += matrix[i][j] * vector[j];
+      }
+    }
+    const sum = next.reduce((acc, cur) => acc + cur, 0);
+    const normalized = next.map((val) => val / sum);
+    const diff = normalized.reduce((acc, cur, idx) => acc + Math.abs(cur - vector[idx]), 0);
+    vector = normalized;
+    if (diff < tolerance) {
+      break;
+    }
+  }
+  const lambdaMax = vector.reduce((acc, _, idx) => {
+    const rowSum = matrix[idx].reduce((sum, val, j) => sum + val * vector[j], 0);
+    return acc + rowSum / vector[idx];
+  }, 0);
+  const ci = (lambdaMax / n - 1) / (n - 1);
+  const riTable: Record<number, number> = {
+    1: 0,
+    2: 0,
+    3: 0.58,
+    4: 0.9,
+    5: 1.12,
+    6: 1.24,
+    7: 1.32,
+    8: 1.41,
+    9: 1.45
+  };
+  const ri = riTable[n] ?? 1.5;
+  const cr = ri === 0 ? 0 : ci / ri;
+  return { weights: vector, ci, cr, lambdaMax };
+};
+
+export const entropyWeights = (dataset: number[][]) => {
+  const m = dataset.length;
+  const n = dataset[0]?.length ?? 0;
+  const normalized = dataset.map((row) => {
+    const sum = row.reduce((acc, cur) => acc + cur, 0);
+    return row.map((val) => (sum === 0 ? 0 : val / sum));
+  });
+  const k = 1 / Math.log(m || 1);
+  const entropies = Array(n).fill(0).map((_, j) => {
+    let entropy = 0;
+    for (let i = 0; i < m; i += 1) {
+      const pij = normalized[i][j];
+      if (pij > 0) {
+        entropy -= pij * Math.log(pij);
+      }
+    }
+    return k * entropy;
+  });
+  const redundancies = entropies.map((e) => 1 - e);
+  const sumRedundancy = redundancies.reduce((acc, cur) => acc + cur, 0);
+  return redundancies.map((val) => (sumRedundancy === 0 ? 0 : val / sumRedundancy));
+};
+
+export const normalizeWeights = (weights: Record<string, number>) => {
+  const sum = Object.values(weights).reduce((acc, cur) => acc + cur, 0);
+  const normalized: Record<string, number> = {};
+  Object.entries(weights).forEach(([key, value]) => {
+    normalized[key] = sum === 0 ? 0 : Number((value / sum).toFixed(4));
+  });
+  return normalized;
+};
+
+export const applyWeightScheme = (scheme: WeightScheme, indicators: IndicatorNode[]) => {
+  const normalized = normalizeWeights(scheme.indicatorWeights);
+  const payload: Record<string, number> = {};
+  indicators.forEach((indicator) => {
+    payload[indicator.id] = normalized[indicator.id] ?? 0;
+  });
+  return payload;
+};
+
+export const buildRadarSeries = (details: EvaluationResultDetail[]) => {
+  return {
+    indicator: details.map((item) => ({ name: item.indicatorName, max: 100 })),
+    value: details.map((item) => Number(item.score.toFixed(2)))
+  };
+};
+
+export const buildBarSeries = (details: EvaluationResultDetail[]) => {
+  return {
+    categories: details.map((item) => item.indicatorName),
+    values: details.map((item) => Number(item.contribution.toFixed(2)))
+  };
+};

--- a/frontend/src/views/AppLayout.vue
+++ b/frontend/src/views/AppLayout.vue
@@ -1,0 +1,219 @@
+<template>
+  <el-container class="app-shell">
+    <el-aside width="240px" class="app-aside">
+      <div class="logo">城市轨道交通供电设备状态评估系统</div>
+      <el-menu
+        :default-active="activeMenu"
+        class="nav-menu"
+        background-color="transparent"
+        @select="handleMenuSelect"
+      >
+        <el-menu-item index="/app/device">
+          <el-icon><Monitor /></el-icon>
+          <span>设备管理</span>
+        </el-menu-item>
+        <el-menu-item index="/app/eval">
+          <el-icon><DataLine /></el-icon>
+          <span>设备评估</span>
+        </el-menu-item>
+        <el-menu-item index="/app/settings" :disabled="auth.role !== 'admin'">
+          <el-icon><Setting /></el-icon>
+          <span>系统设置</span>
+        </el-menu-item>
+      </el-menu>
+    </el-aside>
+    <el-container>
+      <el-header class="app-header">
+        <div class="header-left">
+          <h1>城市轨道交通供电设备状态评估系统</h1>
+          <p>Urban Rail Traction Power Assessment</p>
+        </div>
+        <div class="header-right">
+          <el-tag type="info" effect="dark" class="role-tag">
+            当前角色：{{ roleLabel }}
+          </el-tag>
+          <el-dropdown trigger="click">
+            <span class="user-entry">
+              <el-avatar size="small">{{ initials }}</el-avatar>
+              <span class="username">{{ auth.username }}</span>
+            </span>
+            <template #dropdown>
+              <el-dropdown-menu>
+                <el-dropdown-item @click="toggleTheme">
+                  <el-icon><Moon /></el-icon>
+                  <span>主题切换</span>
+                </el-dropdown-item>
+                <el-dropdown-item divided @click="onLogout">
+                  <el-icon><SwitchButton /></el-icon>
+                  <span>退出登录</span>
+                </el-dropdown-item>
+              </el-dropdown-menu>
+            </template>
+          </el-dropdown>
+        </div>
+      </el-header>
+      <el-main class="app-main">
+        <router-view />
+      </el-main>
+    </el-container>
+  </el-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { ElMessage } from 'element-plus';
+import { DataLine, Monitor, Moon, Setting, SwitchButton } from '@element-plus/icons-vue';
+import { useAuthStore } from '@/stores/auth';
+
+const auth = useAuthStore();
+const router = useRouter();
+const route = useRoute();
+
+const STORAGE_KEY = 'urban-rail-active-menu';
+const activeMenu = ref<string>(route.path.startsWith('/app') ? route.path : '/app/device');
+
+onMounted(() => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    activeMenu.value = stored;
+    if (stored !== route.path) {
+      router.replace(stored).catch(() => void 0);
+    }
+  }
+});
+
+watch(
+  () => route.path,
+  (val) => {
+    if (val.startsWith('/app')) {
+      activeMenu.value = val;
+      localStorage.setItem(STORAGE_KEY, val);
+    }
+  }
+);
+
+const handleMenuSelect = (index: string) => {
+  router.push(index);
+};
+
+const roleLabel = computed(() => (auth.role === 'admin' ? '管理员' : '普通用户'));
+
+const initials = computed(() => (auth.username?.charAt(0) ?? '访'));
+
+const onLogout = () => {
+  auth.logout();
+  localStorage.removeItem(STORAGE_KEY);
+  router.push('/login');
+  ElMessage.success('您已退出系统');
+};
+
+const theme = ref<'light' | 'dark'>('light');
+
+const applyTheme = () => {
+  const body = document.body;
+  body.setAttribute('data-theme', theme.value);
+  if (theme.value === 'dark') {
+    body.style.backgroundColor = '#101828';
+    body.style.color = '#f8fafc';
+  } else {
+    body.style.backgroundColor = '#f2f4f8';
+    body.style.color = 'var(--text-color)';
+  }
+};
+
+const toggleTheme = () => {
+  theme.value = theme.value === 'light' ? 'dark' : 'light';
+  applyTheme();
+  ElMessage.info(`切换为${theme.value === 'dark' ? '暗色' : '亮色'}主题`);
+};
+
+watch(theme, () => applyTheme());
+
+applyTheme();
+</script>
+
+<style scoped>
+.app-shell {
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f7faff 0%, #eef3ff 100%);
+}
+
+.app-aside {
+  background: rgba(22, 93, 255, 0.08);
+  border-right: 1px solid rgba(22, 93, 255, 0.15);
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.logo {
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--primary-color);
+  text-align: center;
+  padding: 12px 8px;
+  border-radius: 12px;
+  background: rgba(22, 93, 255, 0.12);
+}
+
+.nav-menu {
+  flex: 1;
+  background: transparent;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 32px;
+  background: #ffffff;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
+}
+
+.header-left h1 {
+  margin: 0;
+  font-size: 20px;
+  color: var(--text-color);
+}
+
+.header-left p {
+  margin: 4px 0 0;
+  color: var(--muted-color);
+  font-size: 12px;
+  letter-spacing: 0.8px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.user-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(22, 93, 255, 0.08);
+  color: var(--text-color);
+}
+
+.username {
+  font-weight: 500;
+}
+
+.role-tag {
+  border-radius: 999px;
+}
+
+.app-main {
+  background: #f5f7fb;
+  padding: 24px 32px 40px;
+  min-height: calc(100vh - 120px);
+}
+</style>

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -1,0 +1,137 @@
+<template>
+  <div class="login-wrapper">
+    <div class="login-header">
+      <h1>城市轨道交通供电设备状态评估系统</h1>
+      <p>Urban Rail Traction Power Assessment</p>
+    </div>
+    <el-card class="login-card" shadow="always">
+      <el-tabs v-model="activeTab" class="login-tabs">
+        <el-tab-pane label="用户登录" name="user" />
+        <el-tab-pane label="管理员登录" name="admin" />
+      </el-tabs>
+      <el-form
+        ref="formRef"
+        :model="form"
+        :rules="rules"
+        label-position="top"
+        @keyup.enter="handleSubmit"
+      >
+        <el-form-item label="用户名" prop="username">
+          <el-input v-model="form.username" placeholder="请输入用户名" clearable />
+        </el-form-item>
+        <el-form-item label="密码" prop="password">
+          <el-input
+            v-model="form.password"
+            type="password"
+            placeholder="请输入密码"
+            show-password
+          />
+        </el-form-item>
+        <el-form-item>
+          <el-button type="primary" size="large" class="submit-btn" :loading="loading" @click="handleSubmit">
+            进入系统
+          </el-button>
+        </el-form-item>
+      </el-form>
+    </el-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, watch } from 'vue';
+import { useRouter, useRoute } from 'vue-router';
+import { ElForm, ElMessage } from 'element-plus';
+import { useAuthStore } from '@/stores/auth';
+
+type LoginForm = {
+  username: string;
+  password: string;
+};
+
+const router = useRouter();
+const route = useRoute();
+const auth = useAuthStore();
+
+const activeTab = ref<'user' | 'admin'>('user');
+const loading = ref(false);
+
+const form = reactive<LoginForm>({
+  username: '',
+  password: ''
+});
+
+const formRef = ref<InstanceType<typeof ElForm>>();
+
+const rules = {
+  username: [{ required: true, message: '请输入用户名', trigger: 'blur' }],
+  password: [{ required: true, message: '请输入密码', trigger: 'blur' }]
+};
+
+watch(activeTab, () => {
+  form.username = '';
+  form.password = '';
+});
+
+const handleSubmit = () => {
+  formRef.value?.validate(async (valid) => {
+    if (!valid) {
+      return;
+    }
+    loading.value = true;
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      auth.login({ username: form.username, role: activeTab.value });
+      ElMessage.success('登录成功，欢迎回来');
+      const redirect = (route.query.redirect as string) ?? '/app';
+      router.push(redirect);
+    } finally {
+      loading.value = false;
+    }
+  });
+};
+</script>
+
+<style scoped>
+.login-wrapper {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, rgba(22, 93, 255, 0.2), transparent 60%),
+    #f5f7fb;
+  padding: 48px 16px;
+}
+
+.login-header {
+  text-align: center;
+  color: var(--text-color);
+  margin-bottom: 32px;
+}
+
+.login-header h1 {
+  margin: 0;
+  font-size: 28px;
+}
+
+.login-header p {
+  margin-top: 8px;
+  color: var(--muted-color);
+  letter-spacing: 1px;
+}
+
+.login-card {
+  width: 360px;
+  border-radius: 16px;
+  box-shadow: 0 20px 45px rgba(22, 93, 255, 0.15);
+  border: none;
+}
+
+.login-tabs :deep(.el-tabs__item) {
+  font-size: 16px;
+}
+
+.submit-btn {
+  width: 100%;
+}
+</style>

--- a/frontend/src/views/SystemSettings.vue
+++ b/frontend/src/views/SystemSettings.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="settings-page">
+    <el-empty description="系统设置功能正在规划中，敬请期待" />
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>
+
+<style scoped>
+.settings-page {
+  min-height: calc(100vh - 160px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+</style>

--- a/frontend/src/views/device/DevicePage.vue
+++ b/frontend/src/views/device/DevicePage.vue
@@ -1,0 +1,490 @@
+<template>
+  <div class="device-page">
+    <el-card class="toolbar-card" shadow="hover">
+      <div class="toolbar">
+        <div class="toolbar-left">
+          <el-select v-model="deviceStore.currentSystemId" placeholder="选择设备系统" @change="handleSystemChange">
+            <el-option
+              v-for="system in deviceStore.systems"
+              :key="system.id"
+              :label="system.name"
+              :value="system.id"
+            />
+          </el-select>
+          <el-input
+            v-model="deviceStore.filter.keyword"
+            placeholder="搜索名称/编码/位置"
+            clearable
+            :prefix-icon="Search"
+            class="filter-item"
+          />
+          <el-select v-model="deviceStore.filter.status" class="filter-item" style="width: 140px">
+            <el-option label="全部状态" value="全部" />
+            <el-option label="正常" value="正常" />
+            <el-option label="关注" value="关注" />
+            <el-option label="预警" value="预警" />
+            <el-option label="严重" value="严重" />
+          </el-select>
+          <el-select v-model="deviceStore.filter.category" class="filter-item" style="width: 180px">
+            <el-option label="全部设备类型" value="全部" />
+            <el-option
+              v-for="category in currentSystem?.categories ?? []"
+              :key="category"
+              :label="category"
+              :value="category"
+            />
+          </el-select>
+        </div>
+        <div class="toolbar-right">
+          <el-button v-if="isAdmin" type="primary" :icon="Plus" @click="handleCreate">
+            新增设备
+          </el-button>
+          <el-button type="default" :icon="Download" @click="exportDevices">导出JSON</el-button>
+        </div>
+      </div>
+    </el-card>
+
+    <el-empty v-if="!deviceStore.filteredDevices.length" description="暂无符合条件的设备" />
+
+    <div v-else class="device-grid">
+      <el-card
+        v-for="device in deviceStore.filteredDevices"
+        :key="device.id"
+        shadow="hover"
+        class="device-card"
+      >
+        <div class="card-header">
+          <div>
+            <h3>{{ device.name }}</h3>
+            <p class="code">编码：{{ device.code }}</p>
+          </div>
+          <el-tag :type="statusTagType(device.status)" effect="dark">{{ device.status }}</el-tag>
+        </div>
+        <div class="card-body">
+          <el-descriptions :column="2" border size="small">
+            <el-descriptions-item label="系统">{{ systemName(device.systemId) }}</el-descriptions-item>
+            <el-descriptions-item label="分类">{{ device.category }}</el-descriptions-item>
+            <el-descriptions-item label="位置">{{ device.location }}</el-descriptions-item>
+            <el-descriptions-item label="投运日期">{{ device.commissionDate }}</el-descriptions-item>
+            <el-descriptions-item label="上次评估">{{ device.lastEvalAt ?? '未评估' }}</el-descriptions-item>
+            <el-descriptions-item label="综合得分">{{ device.score ? device.score.toFixed(1) : '—' }}</el-descriptions-item>
+          </el-descriptions>
+          <div class="params">
+            <h4>关键参数</h4>
+            <el-row :gutter="12">
+              <el-col v-for="(value, key) in device.keyParams" :key="key" :span="12">
+                <div class="param-item">
+                  <span class="label">{{ key }}</span>
+                  <span class="value">{{ value }}</span>
+                </div>
+              </el-col>
+            </el-row>
+          </div>
+        </div>
+        <div class="card-footer">
+          <el-button type="primary" text size="small" @click="handleEdit(device)">
+            编辑
+          </el-button>
+          <el-button
+            v-if="isAdmin"
+            type="danger"
+            text
+            size="small"
+            @click="handleDelete(device.id)"
+          >
+            删除
+          </el-button>
+        </div>
+      </el-card>
+    </div>
+
+    <el-drawer v-model="drawerVisible" size="520px" :title="drawerTitle">
+      <el-form ref="formRef" :model="form" :rules="rules" label-width="98px">
+        <el-form-item label="设备名称" prop="name">
+          <el-input v-model="form.name" :disabled="!isAdmin" />
+        </el-form-item>
+        <el-form-item label="设备编码" prop="code">
+          <el-input v-model="form.code" :disabled="formMode === 'edit' || !isAdmin" />
+        </el-form-item>
+        <el-form-item label="所属系统" prop="systemId">
+          <el-select v-model="form.systemId" :disabled="!isAdmin">
+            <el-option
+              v-for="system in deviceStore.systems"
+              :key="system.id"
+              :label="system.name"
+              :value="system.id"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="设备类型" prop="category">
+          <el-select v-model="form.category" :disabled="!isAdmin">
+            <el-option
+              v-for="category in availableCategories"
+              :key="category"
+              :label="category"
+              :value="category"
+            />
+          </el-select>
+        </el-form-item>
+        <el-form-item label="安装位置" prop="location">
+          <el-input v-model="form.location" :disabled="!isAdmin" />
+        </el-form-item>
+        <el-form-item label="投运日期" prop="commissionDate">
+          <el-date-picker
+            v-model="form.commissionDate"
+            value-format="YYYY-MM-DD"
+            :disabled="!isAdmin"
+          />
+        </el-form-item>
+        <el-form-item label="状态">
+          <el-select v-model="form.status" :disabled="!isAdmin">
+            <el-option label="正常" value="正常" />
+            <el-option label="关注" value="关注" />
+            <el-option label="预警" value="预警" />
+            <el-option label="严重" value="严重" />
+          </el-select>
+        </el-form-item>
+        <el-divider>关键参数</el-divider>
+        <div class="key-params">
+          <div
+            v-for="(item, index) in form.keyParams"
+            :key="index"
+            class="key-param-row"
+          >
+            <el-input v-model="item.key" placeholder="参数名称" :disabled="!isAdmin && index < lockedParamCount" />
+            <el-input v-model="item.value" placeholder="参数值" />
+            <el-button
+              v-if="isAdmin || index >= lockedParamCount"
+              type="danger"
+              text
+              @click="removeParam(index)"
+            >
+              移除
+            </el-button>
+          </div>
+          <el-button type="primary" text :icon="Plus" @click="addParam">新增参数</el-button>
+        </div>
+      </el-form>
+      <template #footer>
+        <div class="drawer-footer">
+          <el-button @click="drawerVisible = false">取消</el-button>
+          <el-button type="primary" :loading="saving" @click="handleSave">保存</el-button>
+        </div>
+      </template>
+    </el-drawer>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import { ElForm, ElMessage, ElMessageBox } from 'element-plus';
+import { Download, Plus, Search } from '@element-plus/icons-vue';
+import { useAuthStore } from '@/stores/auth';
+import { useDeviceStore } from '@/stores/device';
+import type { DeviceRecord } from '@/types/device';
+
+const auth = useAuthStore();
+const deviceStore = useDeviceStore();
+
+const isAdmin = computed(() => auth.role === 'admin');
+const currentSystem = computed(() =>
+  deviceStore.systems.find((item) => item.id === deviceStore.currentSystemId)
+);
+
+const availableCategories = computed(() => currentSystem.value?.categories ?? []);
+
+const handleSystemChange = (id: string) => {
+  deviceStore.setSystem(id);
+};
+
+const systemName = (id: string) => deviceStore.systems.find((sys) => sys.id === id)?.name ?? '—';
+
+const statusTagType = (status: string) => {
+  switch (status) {
+    case '正常':
+      return 'success';
+    case '关注':
+      return 'info';
+    case '预警':
+      return 'warning';
+    default:
+      return 'danger';
+  }
+};
+
+type FormMode = 'create' | 'edit';
+
+const drawerVisible = ref(false);
+const formMode = ref<FormMode>('create');
+const saving = ref(false);
+
+interface KeyParamRow {
+  key: string;
+  value: string | number;
+}
+
+const form = reactive({
+  id: '',
+  name: '',
+  code: '',
+  systemId: deviceStore.currentSystemId,
+  category: '',
+  location: '',
+  commissionDate: '',
+  status: '正常',
+  ownerRole: auth.role,
+  keyParams: [] as KeyParamRow[],
+  metrics: [] as DeviceRecord['metrics']
+});
+
+const lockedParamCount = ref(0);
+
+watch(
+  () => form.systemId,
+  (val) => {
+    if (!val) return;
+    const categories = deviceStore.systems.find((item) => item.id === val)?.categories ?? [];
+    if (!categories.includes(form.category)) {
+      form.category = categories[0] ?? '';
+    }
+  }
+);
+
+const rules = {
+  name: [{ required: true, message: '请输入设备名称', trigger: 'blur' }],
+  code: [{ required: true, message: '请输入设备编码', trigger: 'blur' }],
+  systemId: [{ required: true, message: '请选择系统', trigger: 'change' }],
+  category: [{ required: true, message: '请选择设备类型', trigger: 'change' }],
+  location: [{ required: true, message: '请输入安装位置', trigger: 'blur' }],
+  commissionDate: [{ required: true, message: '请选择投运日期', trigger: 'change' }]
+};
+
+const formRef = ref<InstanceType<typeof ElForm>>();
+
+const resetForm = () => {
+  form.id = '';
+  form.name = '';
+  form.code = '';
+  form.systemId = deviceStore.currentSystemId;
+  form.category = availableCategories.value[0] ?? '';
+  form.location = '';
+  form.commissionDate = '';
+  form.status = '正常';
+  form.ownerRole = auth.role;
+  form.keyParams = [];
+  form.metrics = [];
+  lockedParamCount.value = 0;
+};
+
+const toParamRows = (params: Record<string, string | number>): KeyParamRow[] => {
+  return Object.entries(params).map(([key, value]) => ({ key, value }));
+};
+
+const fromParamRows = (rows: KeyParamRow[]) => {
+  return rows.reduce<Record<string, string | number>>((acc, cur) => {
+    if (cur.key) {
+      acc[cur.key] = cur.value;
+    }
+    return acc;
+  }, {});
+};
+
+const handleCreate = () => {
+  resetForm();
+  formMode.value = 'create';
+  drawerVisible.value = true;
+};
+
+const handleEdit = (device: DeviceRecord) => {
+  formMode.value = 'edit';
+  form.id = device.id;
+  form.name = device.name;
+  form.code = device.code;
+  form.systemId = device.systemId;
+  form.category = device.category;
+  form.location = device.location;
+  form.commissionDate = device.commissionDate;
+  form.status = device.status;
+  form.ownerRole = device.ownerRole;
+  form.keyParams = toParamRows(device.keyParams);
+  form.metrics = JSON.parse(JSON.stringify(device.metrics));
+  lockedParamCount.value = device.ownerRole === 'admin' ? 0 : form.keyParams.length;
+  drawerVisible.value = true;
+};
+
+const drawerTitle = computed(() => (formMode.value === 'create' ? '新增设备' : '编辑设备'));
+
+const addParam = () => {
+  form.keyParams.push({ key: '', value: '' });
+};
+
+const removeParam = (index: number) => {
+  form.keyParams.splice(index, 1);
+};
+
+const handleSave = () => {
+  formRef.value?.validate(async (valid) => {
+    if (!valid) return;
+    saving.value = true;
+    try {
+      const payload: DeviceRecord = {
+        id: formMode.value === 'create' ? form.code : form.id,
+        name: form.name,
+        code: form.code,
+        systemId: form.systemId,
+        category: form.category,
+        location: form.location,
+        commissionDate: form.commissionDate,
+        status: form.status,
+        ownerRole: form.ownerRole,
+        keyParams: fromParamRows(form.keyParams),
+        metrics: form.metrics
+      };
+      if (formMode.value === 'create') {
+        deviceStore.upsertDevice(payload);
+      } else {
+        deviceStore.updateDevice(payload.id, payload);
+      }
+      ElMessage.success('保存成功');
+      drawerVisible.value = false;
+    } finally {
+      saving.value = false;
+    }
+  });
+};
+
+const handleDelete = (id: string) => {
+  ElMessageBox.confirm('确认删除该设备吗？操作不可恢复', '提示', {
+    type: 'warning'
+  }).then(() => {
+    deviceStore.removeDevice(id);
+    ElMessage.success('设备已删除');
+  });
+};
+
+const exportDevices = () => {
+  const data = JSON.stringify(deviceStore.filteredDevices, null, 2);
+  const blob = new Blob([data], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${currentSystem.value?.name ?? '设备'}-列表.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+  ElMessage.success('导出成功');
+};
+</script>
+
+<style scoped>
+.device-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.toolbar-card {
+  border-radius: 16px;
+}
+
+.toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-item {
+  width: 220px;
+}
+
+.device-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 20px;
+}
+
+.device-card {
+  border-radius: 16px;
+  border: none;
+  background: linear-gradient(180deg, #ffffff 0%, #f9fbff 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 340px;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.card-header h3 {
+  margin: 0;
+  color: var(--text-color);
+}
+
+.card-header .code {
+  margin: 4px 0 0;
+  color: var(--muted-color);
+  font-size: 13px;
+}
+
+.params {
+  margin-top: 12px;
+}
+
+.params h4 {
+  margin: 0 0 8px;
+  font-size: 14px;
+  color: var(--text-color);
+}
+
+.param-item {
+  background: rgba(22, 93, 255, 0.08);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 13px;
+}
+
+.param-item .label {
+  color: var(--muted-color);
+}
+
+.card-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.key-params {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.key-param-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.drawer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+</style>

--- a/frontend/src/views/eval/EvaluationPage.vue
+++ b/frontend/src/views/eval/EvaluationPage.vue
@@ -1,0 +1,1048 @@
+<template>
+  <div class="evaluation-page">
+    <el-row :gutter="20">
+      <el-col :span="24">
+        <el-card shadow="hover" class="module-card">
+          <template #header>
+            <div class="card-header">
+              <div>
+                <h2>卡片 A：指标体系选择</h2>
+                <p>依据配置选择需要参与评估的指标体系及具体指标</p>
+              </div>
+              <el-select v-model="evaluationStore.activeSystemId" placeholder="选择指标体系" @change="handleSystemChange">
+                <el-option
+                  v-for="system in evaluationStore.systemOptions"
+                  :key="system.id"
+                  :label="system.name"
+                  :value="system.id"
+                />
+              </el-select>
+            </div>
+          </template>
+
+          <el-row :gutter="20">
+            <el-col :span="8">
+              <el-card class="inner-card" shadow="never">
+                <template #header>
+                  <div class="inner-header">
+                    <span>指标方案</span>
+                    <el-tag type="info" effect="plain">
+                      至少选择 {{ evaluationStore.activeSystem?.minPrimarySelection ?? 1 }} 个一级指标
+                    </el-tag>
+                  </div>
+                </template>
+                <el-tree
+                  ref="treeRef"
+                  :data="indicatorTreeData"
+                  show-checkbox
+                  node-key="id"
+                  :default-expanded-keys="expandedKeys"
+                  :default-checked-keys="evaluationStore.selectedIndicatorIds"
+                  :props="treeProps"
+                  @check="handleIndicatorCheck"
+                />
+              </el-card>
+            </el-col>
+            <el-col :span="8">
+              <el-card class="inner-card" shadow="never">
+                <template #header>
+                  <div class="inner-header">
+                    <span>指标定义</span>
+                  </div>
+                </template>
+                <el-empty v-if="!activeIndicator" description="请选择指标查看详细定义" />
+                <div v-else class="indicator-detail">
+                  <h3>{{ activeIndicator.name }}</h3>
+                  <p class="definition">{{ activeIndicator.definition }}</p>
+                  <el-descriptions :column="1" border size="small">
+                    <el-descriptions-item label="指标编号">{{ activeIndicator.id }}</el-descriptions-item>
+                    <el-descriptions-item label="单位">{{ activeIndicator.unit ?? '—' }}</el-descriptions-item>
+                    <el-descriptions-item label="方向">
+                      {{ directionLabel(activeIndicator.direction) }}
+                    </el-descriptions-item>
+                    <el-descriptions-item label="阈值/评分规则">
+                      <el-space direction="vertical" alignment="stretch">
+                        <el-tag v-for="rule in activeIndicator.rules" :key="rule.label" type="info">
+                          {{ rule.label }} → {{ rule.score }} 分
+                        </el-tag>
+                      </el-space>
+                    </el-descriptions-item>
+                  </el-descriptions>
+                </div>
+              </el-card>
+            </el-col>
+            <el-col :span="8">
+              <el-card class="inner-card" shadow="never">
+                <template #header>
+                  <div class="inner-header">
+                    <span>已选指标</span>
+                  </div>
+                </template>
+                <el-timeline>
+                  <el-timeline-item
+                    v-for="indicator in evaluationStore.selectedIndicators"
+                    :key="indicator.id"
+                    :timestamp="indicator.id"
+                  >
+                    {{ indicator.name }}
+                  </el-timeline-item>
+                </el-timeline>
+                <div class="selection-actions">
+                  <el-button size="small" type="primary" @click="selectAllIndicators">
+                    全选叶子指标
+                  </el-button>
+                  <el-button size="small" @click="clearSelection">清空选择</el-button>
+                  <el-alert
+                    v-if="!selectionValid"
+                    title="请选择足够的一级指标"
+                    type="warning"
+                    show-icon
+                    :closable="false"
+                    class="mt-12"
+                  />
+                </div>
+              </el-card>
+            </el-col>
+          </el-row>
+        </el-card>
+      </el-col>
+    </el-row>
+
+    <el-row :gutter="20">
+      <el-col :span="24">
+        <el-card shadow="hover" class="module-card">
+          <template #header>
+            <div class="card-header">
+              <div>
+                <h2>卡片 B：指标权重计算</h2>
+                <p>提供 AHP、熵权法以及手工录入三种方案，并可保存为权重方案</p>
+              </div>
+              <el-space>
+                <el-select v-model="evaluationStore.activeSchemeId" placeholder="选择权重方案">
+                  <el-option
+                    v-for="scheme in evaluationStore.weightSchemes"
+                    :key="scheme.id"
+                    :label="scheme.name"
+                    :value="scheme.id"
+                  />
+                </el-select>
+                <el-button @click="handleExportSchemes">导出方案</el-button>
+                <el-upload :auto-upload="false" accept="application/json" :on-change="handleImportSchemes">
+                  <el-button>导入方案</el-button>
+                </el-upload>
+              </el-space>
+            </div>
+          </template>
+
+          <el-tabs v-model="activeWeightTab">
+            <el-tab-pane label="AHP 层次分析法" name="ahp">
+              <div class="tab-wrapper">
+                <el-alert
+                  title="使用 1-9 标度对指标进行两两比较，系统自动完成特征向量与一致性检验"
+                  type="info"
+                  show-icon
+                />
+                <div class="matrix-table" v-if="indicatorList.length">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>指标</th>
+                        <th v-for="indicator in indicatorList" :key="indicator.id">{{ indicator.name }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="(row, rowIndex) in ahpMatrix" :key="indicatorList[rowIndex].id">
+                        <th>{{ indicatorList[rowIndex].name }}</th>
+                        <td v-for="(value, colIndex) in row" :key="colIndex">
+                          <el-input-number
+                            v-model="ahpMatrix[rowIndex][colIndex]"
+                            :min="1"
+                            :max="9"
+                            :precision="2"
+                            :disabled="rowIndex === colIndex"
+                            @change="(val) => handleAhpInput(rowIndex, colIndex, Number(val))"
+                          />
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div v-else class="empty-tip">
+                  <el-empty description="请先选择指标" />
+                </div>
+                <div class="tab-actions">
+                  <el-button type="primary" :disabled="!indicatorList.length" @click="computeAHP">
+                    计算权重
+                  </el-button>
+                  <el-button
+                    type="success"
+                    :disabled="!ahpResult || ahpResult?.cr >= 0.1"
+                    @click="saveAhpScheme"
+                  >
+                    保存为方案
+                  </el-button>
+                  <el-tag v-if="ahpResult" :type="ahpResult.cr < 0.1 ? 'success' : 'warning'">
+                    CI={{ ahpResult.ci.toFixed(3) }} / CR={{ ahpResult.cr.toFixed(3) }}
+                  </el-tag>
+                </div>
+                <el-table v-if="ahpResult" :data="ahpTable" border stripe size="small">
+                  <el-table-column prop="name" label="指标" />
+                  <el-table-column prop="weight" label="权重" />
+                </el-table>
+              </div>
+            </el-tab-pane>
+            <el-tab-pane label="熵权法" name="entropy">
+              <div class="tab-wrapper">
+                <el-alert
+                  title="录入样本数据，熵权法根据信息熵自动计算客观权重"
+                  type="info"
+                  show-icon
+                />
+                <div v-if="indicatorList.length">
+                  <el-table :data="entropySamples" border size="small">
+                    <el-table-column prop="index" label="样本" width="80">
+                      <template #default="{ $index }">样本 {{ $index + 1 }}</template>
+                    </el-table-column>
+                    <el-table-column
+                      v-for="(indicator, index) in indicatorList"
+                      :key="indicator.id"
+                      :label="indicator.name"
+                    >
+                      <template #default="{ row }">
+                        <el-input-number
+                          v-model="row.values[index]"
+                          :min="0"
+                          :max="9999"
+                          :step="0.1"
+                        />
+                      </template>
+                    </el-table-column>
+                    <el-table-column label="操作" width="120">
+                      <template #default="{ $index }">
+                        <el-button type="text" @click="removeEntropySample($index)">删除</el-button>
+                      </template>
+                    </el-table-column>
+                  </el-table>
+                  <div class="tab-actions">
+                    <el-button type="primary" @click="addEntropySample">新增样本</el-button>
+                    <el-button type="primary" @click="computeEntropy">计算权重</el-button>
+                    <el-button type="success" :disabled="!entropyResult" @click="saveEntropyScheme">
+                      保存为方案
+                    </el-button>
+                  </div>
+                  <el-table v-if="entropyResult" :data="entropyTable" border size="small">
+                    <el-table-column prop="name" label="指标" />
+                    <el-table-column prop="weight" label="权重" />
+                  </el-table>
+                </div>
+                <div v-else class="empty-tip">
+                  <el-empty description="请先选择指标" />
+                </div>
+              </div>
+            </el-tab-pane>
+            <el-tab-pane label="手工权重" name="manual">
+              <div class="tab-wrapper">
+                <el-alert
+                  title="直接录入权重值，系统校验权重和应为 1"
+                  type="info"
+                  show-icon
+                />
+                <div v-if="indicatorList.length">
+                  <el-table :data="manualTable" border size="small">
+                    <el-table-column prop="name" label="指标" />
+                    <el-table-column label="权重">
+                      <template #default="{ row }">
+                        <el-input-number
+                          v-model="manualWeights[row.id]"
+                          :min="0"
+                          :max="1"
+                          :step="0.01"
+                        />
+                      </template>
+                    </el-table-column>
+                  </el-table>
+                  <div class="tab-actions">
+                    <el-tag :type="Math.abs(manualWeightSum - 1) < 0.01 ? 'success' : 'warning'">
+                      权重和：{{ manualWeightSum.toFixed(3) }}
+                    </el-tag>
+                    <el-button
+                      type="success"
+                      :disabled="Math.abs(manualWeightSum - 1) >= 0.01"
+                      @click="saveManualScheme"
+                    >
+                      保存为方案
+                    </el-button>
+                  </div>
+                </div>
+                <div v-else class="empty-tip">
+                  <el-empty description="请先选择指标" />
+                </div>
+              </div>
+            </el-tab-pane>
+          </el-tabs>
+        </el-card>
+      </el-col>
+    </el-row>
+
+    <el-row :gutter="20">
+      <el-col :span="24">
+        <el-card shadow="hover" class="module-card">
+          <template #header>
+            <div class="card-header">
+              <div>
+                <h2>卡片 C：设备状态评估与等级划分</h2>
+                <p>选择设备清单与权重方案，执行综合评估并查看可视化结果</p>
+              </div>
+              <el-space>
+                <el-select v-model="evaluationSystemId" placeholder="选择设备系统" style="width: 200px">
+                  <el-option
+                    v-for="system in deviceStore.systems"
+                    :key="system.id"
+                    :label="system.name"
+                    :value="system.id"
+                  />
+                </el-select>
+                <el-select v-model="selectedSchemeId" placeholder="选择权重方案" style="width: 220px">
+                  <el-option
+                    v-for="scheme in evaluationStore.weightSchemes"
+                    :key="scheme.id"
+                    :label="scheme.name"
+                    :value="scheme.id"
+                  />
+                </el-select>
+                <el-button type="primary" :disabled="!canEvaluate" @click="handleEvaluate">
+                  执行评估
+                </el-button>
+                <el-button :disabled="!evaluationResults.length" @click="exportEvaluation">导出结果</el-button>
+              </el-space>
+            </div>
+          </template>
+
+          <el-row :gutter="20">
+            <el-col :span="8">
+              <el-card class="inner-card" shadow="never">
+                <template #header>
+                  <div class="inner-header">
+                    <span>设备列表</span>
+                  </div>
+                </template>
+                <el-checkbox-group v-model="selectedDeviceIds" class="device-checkbox-list">
+                  <el-checkbox
+                    v-for="device in availableDevices"
+                    :key="device.id"
+                    :label="device.id"
+                  >
+                    {{ device.name }}（{{ device.status }}）
+                  </el-checkbox>
+                </el-checkbox-group>
+                <el-alert
+                  v-if="!selectedDeviceIds.length"
+                  title="请选择至少一台设备"
+                  type="warning"
+                  show-icon
+                  :closable="false"
+                  class="mt-12"
+                />
+              </el-card>
+            </el-col>
+            <el-col :span="16">
+              <div class="results-area">
+                <el-tabs v-if="evaluationResults.length" v-model="activeResultId">
+                  <el-tab-pane
+                    v-for="result in evaluationResults"
+                    :key="result.deviceId"
+                    :label="`${result.deviceName}（${result.level}）`"
+                    :name="result.deviceId"
+                  >
+                    <el-row :gutter="20">
+                      <el-col :span="12">
+                        <el-card shadow="never" class="result-card">
+                          <div class="score-block">
+                            <h3>综合得分</h3>
+                            <span class="score">{{ result.totalScore.toFixed(1) }}</span>
+                            <el-tag :type="gradeTagType(result.level)" effect="dark">
+                              等级 {{ result.level }}
+                            </el-tag>
+                          </div>
+                          <ul class="detail-list">
+                            <li v-for="detail in result.details" :key="detail.indicatorId">
+                              <span>{{ detail.indicatorName }}</span>
+                              <span>{{ formatRawValue(detail.rawValue) }} → {{ detail.score.toFixed(1) }}分</span>
+                            </li>
+                          </ul>
+                        </el-card>
+                      </el-col>
+                      <el-col :span="12">
+                        <el-card shadow="never" class="result-card">
+                          <RadarChart
+                            v-if="detailsMap[result.deviceId]"
+                            :title="'短板指标雷达图'"
+                            :indicator="detailsMap[result.deviceId].radar.indicator"
+                            :value="detailsMap[result.deviceId].radar.value"
+                          />
+                          <el-empty v-else description="暂无数据" />
+                        </el-card>
+                        <el-card shadow="never" class="result-card">
+                          <BarChart
+                            v-if="detailsMap[result.deviceId]"
+                            :title="'指标贡献柱状图'"
+                            :categories="detailsMap[result.deviceId].bar.categories"
+                            :values="detailsMap[result.deviceId].bar.values"
+                          />
+                          <el-empty v-else description="暂无数据" />
+                        </el-card>
+                      </el-col>
+                    </el-row>
+                  </el-tab-pane>
+                </el-tabs>
+                <el-empty v-else description="尚未执行评估" />
+              </div>
+            </el-col>
+          </el-row>
+
+          <el-divider />
+
+          <div class="history-section">
+            <div class="history-header">
+              <h3>最近评估记录</h3>
+              <el-button text type="danger" @click="clearHistory">清空历史</el-button>
+            </div>
+            <el-table :data="evaluationStore.history" border size="small">
+              <el-table-column prop="deviceName" label="设备" />
+              <el-table-column prop="systemId" label="系统" />
+              <el-table-column prop="totalScore" label="综合得分">
+                <template #default="{ row }">{{ row.totalScore.toFixed(1) }}</template>
+              </el-table-column>
+              <el-table-column prop="level" label="等级" />
+              <el-table-column prop="evaluatedAt" label="评估时间" />
+            </el-table>
+            <TrendChart
+              v-if="evaluationStore.history.length"
+              :title="'综合得分趋势'"
+              :categories="trendCategories"
+              :values="trendValues"
+            />
+          </div>
+        </el-card>
+      </el-col>
+    </el-row>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, reactive, ref, watch } from 'vue';
+import { ElMessage, ElMessageBox, ElTree } from 'element-plus';
+import { useEvaluationStore } from '@/stores/evaluation';
+import { useDeviceStore } from '@/stores/device';
+import {
+  ahpPowerIteration,
+  applyWeightScheme,
+  buildBarSeries,
+  buildRadarSeries,
+  computeDeviceScore,
+  determineLevel,
+  entropyWeights
+} from '@/utils/evaluation';
+import RadarChart from '@/charts/RadarChart.vue';
+import BarChart from '@/charts/BarChart.vue';
+import TrendChart from '@/charts/TrendChart.vue';
+import type { DeviceEvaluationResult, IndicatorNode } from '@/types/evaluation';
+
+const evaluationStore = useEvaluationStore();
+const deviceStore = useDeviceStore();
+
+const treeRef = ref<InstanceType<typeof ElTree>>();
+const activeIndicator = ref<IndicatorNode | null>(null);
+
+const treeProps = {
+  label: 'label',
+  children: 'children'
+};
+
+const indicatorTreeData = computed(() => {
+  const transform = (nodes: IndicatorNode[]): any[] =>
+    nodes.map((node) => ({
+      id: node.id,
+      label: node.name,
+      node,
+      children: node.children ? transform(node.children) : undefined
+    }));
+  return transform(evaluationStore.activeSystem?.tree ?? []);
+});
+
+const expandedKeys = computed(() => indicatorTreeData.value.map((item) => item.id));
+
+const indicatorList = computed(() => evaluationStore.selectedIndicators);
+
+const directionLabel = (direction: string) => {
+  switch (direction) {
+    case 'positive':
+      return '极大型指标（越大越好）';
+    case 'negative':
+      return '极小型指标（越小越好）';
+    default:
+      return '区间型指标（越接近区间越好）';
+  }
+};
+
+const handleIndicatorCheck = (data: any, checked: any) => {
+  if (data?.node) {
+    activeIndicator.value = data.node;
+  }
+  const keys = (treeRef.value?.getCheckedKeys(true) as string[]) ?? [];
+  evaluationStore.setIndicators(keys);
+};
+
+const selectAllIndicators = () => {
+  const leaves: string[] = [];
+  const walk = (items: any[]) => {
+    items.forEach((item) => {
+      if (!item.children?.length) {
+        leaves.push(item.id);
+      } else {
+        walk(item.children);
+      }
+    });
+  };
+  walk(indicatorTreeData.value);
+  evaluationStore.setIndicators(leaves);
+  nextTick(() => {
+    treeRef.value?.setCheckedKeys(leaves);
+  });
+};
+
+const clearSelection = () => {
+  evaluationStore.setIndicators([]);
+  treeRef.value?.setCheckedKeys([]);
+};
+
+const selectionValid = computed(() => evaluationStore.validateSelection());
+
+const handleSystemChange = (id: string) => {
+  evaluationStore.setActiveSystem(id);
+  nextTick(() => {
+    treeRef.value?.setCheckedKeys(evaluationStore.selectedIndicatorIds);
+  });
+};
+
+watch(
+  () => evaluationStore.selectedIndicatorIds,
+  (val) => {
+    nextTick(() => {
+      treeRef.value?.setCheckedKeys(val);
+    });
+  }
+);
+
+watch(indicatorList, (list) => {
+  if (!list.length) {
+    activeIndicator.value = null;
+  }
+  if (list.length && !activeIndicator.value) {
+    activeIndicator.value = list[0];
+  }
+  rebuildAhpMatrix();
+  rebuildManualWeights();
+  rebuildEntropySamples();
+});
+
+const activeWeightTab = ref('ahp');
+
+// AHP
+const ahpMatrix = ref<number[][]>([]);
+const ahpResult = ref<{ weights: number[]; ci: number; cr: number; lambdaMax: number } | null>(null);
+
+const rebuildAhpMatrix = () => {
+  const size = indicatorList.value.length;
+  ahpMatrix.value = Array.from({ length: size }, (_, row) =>
+    Array.from({ length: size }, (_, col) => (row === col ? 1 : 1))
+  );
+  ahpResult.value = null;
+};
+
+const handleAhpInput = (row: number, col: number, value: number) => {
+  if (row === col) return;
+  const sanitized = Math.min(Math.max(value || 1, 1 / 9), 9);
+  ahpMatrix.value[row][col] = sanitized;
+  ahpMatrix.value[col][row] = Number((1 / sanitized).toFixed(4));
+};
+
+const ahpTable = computed(() => {
+  if (!ahpResult.value) return [];
+  return indicatorList.value.map((indicator, index) => ({
+    name: indicator.name,
+    weight: ahpResult.value ? ahpResult.value.weights[index].toFixed(4) : '0'
+  }));
+});
+
+const computeAHP = () => {
+  if (!indicatorList.value.length) return;
+  const matrix = ahpMatrix.value.map((row, rowIndex) =>
+    row.map((value, colIndex) => (rowIndex === colIndex ? 1 : value))
+  );
+  const result = ahpPowerIteration(matrix);
+  ahpResult.value = result;
+  if (result.cr >= 0.1) {
+    ElMessage.warning('一致性检验未通过，CR ≥ 0.1');
+  } else {
+    ElMessage.success('AHP 计算完成，一致性良好');
+  }
+};
+
+const saveAhpScheme = () => {
+  if (!ahpResult.value) return;
+  const weights: Record<string, number> = {};
+  indicatorList.value.forEach((indicator, index) => {
+    weights[indicator.id] = Number(ahpResult.value!.weights[index].toFixed(4));
+  });
+  evaluationStore.saveWeightScheme({
+    id: `scheme-ahp-${Date.now()}`,
+    name: `AHP方案-${new Date().toLocaleString()}`,
+    createdAt: new Date().toISOString(),
+    method: 'AHP',
+    indicatorWeights: weights,
+    description: '基于 AHP 的自动计算方案'
+  });
+  ElMessage.success('AHP 方案已保存');
+};
+
+// Entropy
+interface EntropyRow {
+  values: number[];
+}
+
+const entropySamples = ref<EntropyRow[]>([]);
+const entropyResult = ref<number[] | null>(null);
+
+const rebuildEntropySamples = () => {
+  entropySamples.value = Array.from({ length: 3 }, () => ({
+    values: indicatorList.value.map(() => 1)
+  }));
+  entropyResult.value = null;
+};
+
+const addEntropySample = () => {
+  entropySamples.value.push({ values: indicatorList.value.map(() => 1) });
+};
+
+const removeEntropySample = (index: number) => {
+  if (entropySamples.value.length <= 1) {
+    ElMessage.warning('至少保留一个样本');
+    return;
+  }
+  entropySamples.value.splice(index, 1);
+};
+
+const entropyTable = computed(() => {
+  if (!entropyResult.value) return [];
+  return indicatorList.value.map((indicator, index) => ({
+    name: indicator.name,
+    weight: entropyResult.value ? entropyResult.value[index].toFixed(4) : '0'
+  }));
+});
+
+const computeEntropy = () => {
+  if (!indicatorList.value.length) {
+    ElMessage.warning('请选择指标');
+    return;
+  }
+  const dataset = entropySamples.value.map((row) => row.values);
+  const result = entropyWeights(dataset);
+  entropyResult.value = result;
+  ElMessage.success('熵权法权重已计算');
+};
+
+const saveEntropyScheme = () => {
+  if (!entropyResult.value) return;
+  const weights: Record<string, number> = {};
+  indicatorList.value.forEach((indicator, index) => {
+    weights[indicator.id] = Number(entropyResult.value![index].toFixed(4));
+  });
+  evaluationStore.saveWeightScheme({
+    id: `scheme-entropy-${Date.now()}`,
+    name: `熵权方案-${new Date().toLocaleString()}`,
+    createdAt: new Date().toISOString(),
+    method: 'Entropy',
+    indicatorWeights: weights,
+    description: '基于熵权法计算的方案'
+  });
+  ElMessage.success('熵权方案已保存');
+};
+
+// Manual
+const manualWeights = reactive<Record<string, number>>({});
+
+const rebuildManualWeights = () => {
+  indicatorList.value.forEach((indicator) => {
+    if (!(indicator.id in manualWeights)) {
+      manualWeights[indicator.id] = Number((1 / indicatorList.value.length).toFixed(4));
+    }
+  });
+  Object.keys(manualWeights).forEach((key) => {
+    if (!indicatorList.value.some((indicator) => indicator.id === key)) {
+      delete manualWeights[key];
+    }
+  });
+};
+
+const manualTable = computed(() =>
+  indicatorList.value.map((indicator) => ({ id: indicator.id, name: indicator.name }))
+);
+
+const manualWeightSum = computed(() =>
+  Object.values(manualWeights).reduce((acc, cur) => acc + (Number(cur) || 0), 0)
+);
+
+const saveManualScheme = () => {
+  if (Math.abs(manualWeightSum.value - 1) >= 0.01) {
+    ElMessage.warning('权重和需为 1');
+    return;
+  }
+  evaluationStore.saveWeightScheme({
+    id: `scheme-manual-${Date.now()}`,
+    name: `手工方案-${new Date().toLocaleString()}`,
+    createdAt: new Date().toISOString(),
+    method: 'Manual',
+    indicatorWeights: { ...manualWeights }
+  });
+  ElMessage.success('手工方案已保存');
+};
+
+watch(
+  () => evaluationStore.activeScheme,
+  (scheme) => {
+    if (!scheme) return;
+    Object.keys(manualWeights).forEach((key) => delete manualWeights[key]);
+    Object.entries(scheme.indicatorWeights).forEach(([key, value]) => {
+      manualWeights[key] = Number(value.toFixed(4));
+    });
+  },
+  { immediate: true }
+);
+
+const handleExportSchemes = () => {
+  const content = evaluationStore.exportSchemes();
+  const blob = new Blob([content], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = '权重方案.json';
+  a.click();
+  URL.revokeObjectURL(url);
+  ElMessage.success('权重方案已导出');
+};
+
+const handleImportSchemes = (file: any) => {
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    try {
+      evaluationStore.importSchemes(String(event.target?.result ?? ''));
+      ElMessage.success('导入成功');
+    } catch (error) {
+      console.error(error);
+      ElMessage.error('导入失败，请检查 JSON 格式');
+    }
+  };
+  reader.readAsText(file.raw);
+};
+
+// Evaluation
+const evaluationSystemId = ref(deviceStore.currentSystemId);
+const selectedDeviceIds = ref<string[]>([]);
+const selectedSchemeId = ref(evaluationStore.activeSchemeId);
+const evaluationResults = ref<DeviceEvaluationResult[]>([]);
+const activeResultId = ref<string>('');
+const detailsMap = reactive<Record<
+  string,
+  { radar: ReturnType<typeof buildRadarSeries>; bar: ReturnType<typeof buildBarSeries> }
+>>({});
+
+const availableDevices = computed(() =>
+  deviceStore.devices.filter((device) => device.systemId === evaluationSystemId.value)
+);
+
+watch(
+  () => evaluationSystemId.value,
+  () => {
+    selectedDeviceIds.value = availableDevices.value.slice(0, 3).map((item) => item.id);
+  },
+  { immediate: true }
+);
+
+watch(
+  () => evaluationStore.weightSchemes,
+  () => {
+    if (!evaluationStore.weightSchemes.length) return;
+    if (!selectedSchemeId.value) {
+      selectedSchemeId.value = evaluationStore.weightSchemes[0].id;
+    }
+  },
+  { immediate: true, deep: true }
+);
+
+watch(
+  () => evaluationStore.activeSchemeId,
+  (id) => {
+    if (id) {
+      selectedSchemeId.value = id;
+    }
+  },
+  { immediate: true }
+);
+
+const canEvaluate = computed(
+  () => selectedDeviceIds.value.length > 0 && Boolean(selectedSchemeId.value) && selectionValid.value
+);
+
+const gradeTagType = (level: string) => {
+  switch (level) {
+    case 'A':
+      return 'success';
+    case 'B':
+      return 'info';
+    case 'C':
+      return 'warning';
+    default:
+      return 'danger';
+  }
+};
+
+const formatRawValue = (value: number | string) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : '-';
+  }
+  return value;
+};
+
+const handleEvaluate = () => {
+  if (!canEvaluate.value) {
+    ElMessage.warning('请完善选择');
+    return;
+  }
+  const scheme = evaluationStore.weightSchemes.find((item) => item.id === selectedSchemeId.value);
+  if (!scheme) {
+    ElMessage.error('未找到权重方案');
+    return;
+  }
+  const indicators = evaluationStore.selectedIndicators;
+  const weightMap = applyWeightScheme(scheme, indicators);
+  const selectedDevices = deviceStore.devices.filter((device) =>
+    selectedDeviceIds.value.includes(device.id)
+  );
+  const datasets: Record<string, number[]> = {};
+  indicators.forEach((indicator) => {
+    datasets[indicator.id] = selectedDevices
+      .map((device) => device.metrics.find((item) => item.indicatorId === indicator.id)?.value)
+      .filter((value): value is number => typeof value === 'number');
+  });
+
+  const now = new Date().toISOString();
+  const results = selectedDevices.map((device) => {
+    const { total, details } = computeDeviceScore(device, indicators, weightMap, datasets);
+    const level = determineLevel(total);
+    deviceStore.recordEvaluation({ id: device.id, score: total, level, evaluatedAt: now });
+    return {
+      deviceId: device.id,
+      deviceName: device.name,
+      systemId: device.systemId,
+      totalScore: total,
+      level,
+      evaluatedAt: now,
+      details
+    };
+  });
+  evaluationResults.value = results;
+  activeResultId.value = results[0]?.deviceId ?? '';
+  evaluationStore.appendEvaluationHistory(results);
+  results.forEach((result) => {
+    detailsMap[result.deviceId] = {
+      radar: buildRadarSeries(result.details),
+      bar: buildBarSeries(result.details)
+    };
+  });
+  ElMessage.success('评估完成，结果已更新');
+};
+
+const exportEvaluation = () => {
+  if (!evaluationResults.value.length) return;
+  const content = JSON.stringify(evaluationResults.value, null, 2);
+  const blob = new Blob([content], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = '评估结果.json';
+  a.click();
+  URL.revokeObjectURL(url);
+  ElMessage.success('评估结果已导出');
+};
+
+const clearHistory = () => {
+  ElMessageBox.confirm('确认清空历史记录？', '提示', { type: 'warning' }).then(() => {
+    evaluationStore.clearHistory();
+  });
+};
+
+const trendCategories = computed(() =>
+  evaluationStore.history.map((item) => new Date(item.evaluatedAt).toLocaleString()).reverse()
+);
+const trendValues = computed(() => evaluationStore.history.map((item) => item.totalScore).reverse());
+</script>
+
+<style scoped>
+.evaluation-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.module-card {
+  border-radius: 16px;
+}
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.card-header p {
+  margin: 4px 0 0;
+  color: var(--muted-color);
+}
+
+.inner-card {
+  border-radius: 12px;
+  background: #ffffff;
+}
+
+.inner-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+
+.indicator-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.indicator-detail h3 {
+  margin: 0;
+}
+
+.indicator-detail .definition {
+  margin: 0;
+  color: var(--muted-color);
+}
+
+.selection-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mt-12 {
+  margin-top: 12px;
+}
+
+.tab-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.matrix-table {
+  overflow-x: auto;
+}
+
+.matrix-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.matrix-table th,
+.matrix-table td {
+  border: 1px solid #e4e7ed;
+  padding: 8px;
+  text-align: center;
+}
+
+.tab-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.empty-tip {
+  padding: 40px 0;
+}
+
+.device-checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.results-area {
+  min-height: 360px;
+}
+
+.result-card {
+  margin-bottom: 16px;
+  border-radius: 12px;
+}
+
+.score-block {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.score-block h3 {
+  margin: 0;
+}
+
+.score {
+  font-size: 32px;
+  font-weight: 600;
+  color: #165dff;
+}
+
+.detail-list {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.detail-list li {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-color);
+  font-size: 14px;
+}
+
+.history-section {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.history-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+</style>

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"]
+}

--- a/frontend/tsconfig.base.json
+++ b/frontend/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "tsconfig.app.json" },
+    { "path": "tsconfig.vitest.json", "prepend": false }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/tsconfig.vitest.json
+++ b/frontend/tsconfig.vitest.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": []
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 5173
+  }
+});

--- a/power_evaluation_config.json
+++ b/power_evaluation_config.json
@@ -1,0 +1,406 @@
+{
+  "deviceSystems": [
+    {
+      "id": "main-substation",
+      "name": "主变电所",
+      "description": "供电系统核心枢纽，负责牵引电能的集中变换与分配。",
+      "categories": [
+        "开关设备",
+        "母线",
+        "变压器",
+        "电抗器",
+        "互感器",
+        "电容器",
+        "隔离开关",
+        "交直流电源",
+        "各类电缆及光缆",
+        "保护装置",
+        "变电所综合自动化",
+        "避雷装置",
+        "无功补偿系统"
+      ]
+    },
+    {
+      "id": "sub-substation",
+      "name": "子变电所",
+      "description": "配合主变电所完成牵引供电与降压供电任务。",
+      "categories": [
+        "开关设备",
+        "变压器",
+        "OVPD",
+        "负极柜",
+        "整流器柜",
+        "交直流电源",
+        "各类电缆及光缆",
+        "回流装置",
+        "变电所综合自动化",
+        "保护装置及二次回路"
+      ]
+    },
+    {
+      "id": "catenary",
+      "name": "接触网系统",
+      "description": "刚柔性接触网承载牵引电流，是列车受流的关键系统。",
+      "categories": ["汇流排", "接触线", "承力索", "架空地线", "支柱", "软横跨", "上网隔离开关"]
+    },
+    {
+      "id": "power-lighting",
+      "name": "动力照明系统",
+      "description": "动力与照明用电系统，预留扩展接口。",
+      "categories": ["占位待建"]
+    },
+    {
+      "id": "stray-current",
+      "name": "杂散电流防护系统",
+      "description": "用于控制与引导杂散电流的防护设施。",
+      "categories": ["占位待建"]
+    },
+    {
+      "id": "power-monitor",
+      "name": "电力监控系统",
+      "description": "对供电设备与参数进行实时监测与管理。",
+      "categories": ["占位待建"]
+    }
+  ],
+  "seedDevices": [
+    {
+      "id": "MSS-SW-001",
+      "name": "主变电所开关柜A1",
+      "code": "MSS-SW-001",
+      "systemId": "main-substation",
+      "category": "开关设备",
+      "location": "主变电所A区-开关间",
+      "commissionDate": "2017-06-18",
+      "status": "正常",
+      "ownerRole": "admin",
+      "keyParams": {
+        "额定电流": "1250A",
+        "额定电压": "27.5kV",
+        "操作机构": "智能真空",
+        "制造商": "国电南瑞"
+      },
+      "metrics": [
+        {
+          "indicatorId": "life-cycle.overdue-service",
+          "name": "超出规定服役年限",
+          "value": 2.5,
+          "unit": "年",
+          "updatedAt": "2024-12-01"
+        },
+        {
+          "indicatorId": "reliability.failure-rate",
+          "name": "故障率",
+          "value": 0.8,
+          "unit": "次/万小时",
+          "updatedAt": "2024-12-01"
+        },
+        {
+          "indicatorId": "safety.operation-impact",
+          "name": "对行车安全影响",
+          "value": "无影响",
+          "updatedAt": "2024-12-01"
+        },
+        {
+          "indicatorId": "support.spare-part",
+          "name": "备品备件供应",
+          "value": "满足",
+          "updatedAt": "2024-12-01"
+        }
+      ]
+    },
+    {
+      "id": "MSS-TR-003",
+      "name": "主变电所主变压器T3",
+      "code": "MSS-TR-003",
+      "systemId": "main-substation",
+      "category": "变压器",
+      "location": "主变电所B区-变压器室",
+      "commissionDate": "2012-09-05",
+      "status": "关注",
+      "ownerRole": "admin",
+      "keyParams": {
+        "容量": "2x40MVA",
+        "冷却方式": "ONAF",
+        "分接范围": "±8x1.5%"
+      },
+      "metrics": [
+        {
+          "indicatorId": "life-cycle.overdue-service",
+          "name": "超出规定服役年限",
+          "value": 7,
+          "unit": "年",
+          "updatedAt": "2024-11-20"
+        },
+        {
+          "indicatorId": "reliability.failure-rate",
+          "name": "故障率",
+          "value": 1.4,
+          "unit": "次/万小时",
+          "updatedAt": "2024-11-20"
+        },
+        {
+          "indicatorId": "reliability.mtbf",
+          "name": "无故障间隔时间",
+          "value": 2800,
+          "unit": "小时",
+          "updatedAt": "2024-11-20"
+        },
+        {
+          "indicatorId": "function.integrity",
+          "name": "设备功能完备性",
+          "value": "一般符合",
+          "updatedAt": "2024-11-20"
+        }
+      ]
+    },
+    {
+      "id": "SUB-REC-010",
+      "name": "整流器柜10号",
+      "code": "SUB-REC-010",
+      "systemId": "sub-substation",
+      "category": "整流器柜",
+      "location": "XX线南区子变电所",
+      "commissionDate": "2019-03-12",
+      "status": "正常",
+      "ownerRole": "user",
+      "keyParams": {
+        "类型": "12脉波整流",
+        "冷却": "强迫风冷",
+        "容量": "6MW"
+      },
+      "metrics": [
+        {
+          "indicatorId": "life-cycle.overdue-service",
+          "name": "超出规定服役年限",
+          "value": 1,
+          "unit": "年",
+          "updatedAt": "2024-12-05"
+        },
+        {
+          "indicatorId": "reliability.failure-rate",
+          "name": "故障率",
+          "value": 0.6,
+          "unit": "次/万小时",
+          "updatedAt": "2024-12-05"
+        },
+        {
+          "indicatorId": "support.spare-part",
+          "name": "备品备件供应",
+          "value": "基本满足",
+          "updatedAt": "2024-12-05"
+        }
+      ]
+    },
+    {
+      "id": "CAT-CON-021",
+      "name": "接触线段落K21",
+      "code": "CAT-CON-021",
+      "systemId": "catenary",
+      "category": "接触线",
+      "location": "区间K21+300至K21+800",
+      "commissionDate": "2015-11-01",
+      "status": "预警",
+      "ownerRole": "admin",
+      "keyParams": {
+        "型号": "CUAg 120",
+        "张力": "21kN",
+        "接触面磨耗": "30%"
+      },
+      "metrics": [
+        {
+          "indicatorId": "life-cycle.overdue-service",
+          "name": "超出规定服役年限",
+          "value": 4.5,
+          "unit": "年",
+          "updatedAt": "2024-10-11"
+        },
+        {
+          "indicatorId": "safety.operation-impact",
+          "name": "对行车安全影响",
+          "value": "一般",
+          "updatedAt": "2024-10-11"
+        },
+        {
+          "indicatorId": "function.integrity",
+          "name": "设备功能完备性",
+          "value": "符合",
+          "updatedAt": "2024-10-11"
+        }
+      ]
+    }
+  ],
+  "indicatorSystems": [
+    {
+      "id": "standard-2024",
+      "name": "供电设备状态评估标准方案（2024版）",
+      "applicableSystems": ["main-substation", "sub-substation", "catenary", "power-monitor"],
+      "minPrimarySelection": 3,
+      "tree": [
+        {
+          "id": "life-cycle",
+          "name": "寿命状态",
+          "definition": "设备服役年限与折旧状况",
+          "direction": "negative",
+          "unit": "年",
+          "thresholdDescription": "越大代表服役年限越长，需要关注老化情况",
+          "rules": [
+            { "label": "[0,3)年", "range": [0, 3], "score": 100 },
+            { "label": "[3,5)年", "range": [3, 5], "score": 80 },
+            { "label": "≥5年", "range": [5, null], "score": 60 }
+          ],
+          "children": [
+            {
+              "id": "life-cycle.overdue-service",
+              "name": "超出规定服役年限",
+              "definition": "设备服役年限超出设计年限的时间差",
+              "unit": "年",
+              "direction": "negative",
+              "rules": [
+                { "label": "[0,3)", "range": [0, 3], "score": 100 },
+                { "label": "[3,5)", "range": [3, 5], "score": 80 },
+                { "label": "≥5", "range": [5, null], "score": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "safety",
+          "name": "安全影响",
+          "definition": "设备状态对行车及供电安全的影响程度",
+          "direction": "negative",
+          "rules": [
+            { "label": "无影响", "value": "无影响", "score": 100 },
+            { "label": "一般", "value": "一般", "score": 80 },
+            { "label": "较大", "value": "较大", "score": 60 },
+            { "label": "严重", "value": "严重", "score": 40 }
+          ],
+          "children": [
+            {
+              "id": "safety.operation-impact",
+              "name": "对行车安全性的影响",
+              "definition": "评估设备异常对列车行车安全的影响等级",
+              "direction": "negative",
+              "rules": [
+                { "label": "无影响", "value": "无影响", "score": 100 },
+                { "label": "一般", "value": "一般", "score": 80 },
+                { "label": "较大", "value": "较大", "score": 60 },
+                { "label": "严重", "value": "严重", "score": 40 }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "reliability",
+          "name": "可靠性",
+          "definition": "设备运行故障频率及稳定性指标",
+          "direction": "negative",
+          "rules": [
+            { "label": "故障率≤0.5", "range": [null, 0.5], "score": 100 },
+            { "label": "0.5~1.0", "range": [0.5, 1], "score": 85 },
+            { "label": "1.0~1.5", "range": [1, 1.5], "score": 70 },
+            { "label": ">1.5", "range": [1.5, null], "score": 55 }
+          ],
+          "children": [
+            {
+              "id": "reliability.failure-rate",
+              "name": "故障率",
+              "definition": "设备单位时间内发生故障的次数",
+              "unit": "次/万小时",
+              "direction": "negative",
+              "rules": [
+                { "label": "≤0.5", "range": [null, 0.5], "score": 100 },
+                { "label": "0.5~1.0", "range": [0.5, 1], "score": 85 },
+                { "label": "1.0~1.5", "range": [1, 1.5], "score": 70 },
+                { "label": ">1.5", "range": [1.5, null], "score": 55 }
+              ]
+            },
+            {
+              "id": "reliability.mtbf",
+              "name": "无故障间隔时间",
+              "definition": "设备平均无故障运行时间",
+              "unit": "小时",
+              "direction": "positive",
+              "rules": [
+                { "label": "≥4000", "range": [4000, null], "score": 100 },
+                { "label": "3000~4000", "range": [3000, 4000], "score": 85 },
+                { "label": "2000~3000", "range": [2000, 3000], "score": 70 },
+                { "label": "<2000", "range": [null, 2000], "score": 55 }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "function",
+          "name": "功能完备性",
+          "definition": "设备各单元功能满足设计要求的程度",
+          "direction": "positive",
+          "rules": [
+            { "label": "符合", "value": "符合", "score": 100 },
+            { "label": "一般符合", "value": "一般符合", "score": 80 },
+            { "label": "不符合", "value": "不符合", "score": 60 }
+          ],
+          "children": [
+            {
+              "id": "function.integrity",
+              "name": "设备功能完备性",
+              "definition": "通过现场检查对功能状态进行等级划分",
+              "direction": "positive",
+              "rules": [
+                { "label": "符合", "value": "符合", "score": 100 },
+                { "label": "一般符合", "value": "一般符合", "score": 80 },
+                { "label": "不符合", "value": "不符合", "score": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "id": "support",
+          "name": "保障能力",
+          "definition": "备品备件、检修资源满足程度",
+          "direction": "positive",
+          "rules": [
+            { "label": "满足", "value": "满足", "score": 100 },
+            { "label": "基本满足", "value": "基本满足", "score": 80 },
+            { "label": "无备件", "value": "无备件", "score": 60 }
+          ],
+          "children": [
+            {
+              "id": "support.spare-part",
+              "name": "备品备件供应",
+              "definition": "备件储备与供应满足检修需求的程度",
+              "direction": "positive",
+              "rules": [
+                { "label": "满足", "value": "满足", "score": 100 },
+                { "label": "基本满足", "value": "基本满足", "score": 80 },
+                { "label": "无备件", "value": "无备件", "score": 60 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "defaultWeightSchemes": [
+    {
+      "id": "scheme-ahp-default",
+      "name": "AHP标准权重",
+      "createdAt": "2024-12-01T08:00:00+08:00",
+      "method": "AHP",
+      "description": "依据专家经验建立的基准权重向量",
+      "indicatorWeights": {
+        "life-cycle.overdue-service": 0.25,
+        "safety.operation-impact": 0.2,
+        "reliability.failure-rate": 0.18,
+        "reliability.mtbf": 0.15,
+        "function.integrity": 0.12,
+        "support.spare-part": 0.1
+      }
+    }
+  ],
+  "evaluationLevelRules": [
+    { "level": "A", "min": 90, "max": 100, "description": "正常、可靠性稳定" },
+    { "level": "B", "min": 80, "max": 90, "description": "轻微问题，需部分维护" },
+    { "level": "C", "min": 70, "max": 80, "description": "早期故障特征，需及时维修" },
+    { "level": "D", "min": 0, "max": 70, "description": "问题较重，需大修或更换" }
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffolded a Vue 3 + Vite + TypeScript frontend for the "城市轨道交通供电设备状态评估系统" with Element Plus UI, routing, and global styling
- implemented Pinia stores with localStorage persistence for authentication, device management, and evaluation workflows using configuration derived from power_evaluation_config.json
- built device management and evaluation modules featuring editable device records, indicator selection, multi-method weight computation, comprehensive scoring visuals, and evaluation history tracking

## Testing
- npm install *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db49d3cd7c832293edb750ed57ac12